### PR TITLE
Add IsEmpty / NotEmpty overloads to CountEx

### DIFF
--- a/src/DynamicData/Aggregation/CountEx.cs
+++ b/src/DynamicData/Aggregation/CountEx.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for full license information.
 
 using System;
+using System.Reactive.Linq;
 
 namespace DynamicData.Aggregation
 {
@@ -56,6 +57,68 @@ namespace DynamicData.Aggregation
         public static IObservable<int> Count<TObject>(this IObservable<IDistinctChangeSet<TObject>> source)
         {
             return source.ForAggregation().Count();
+        }
+
+        /// <summary>
+        /// Counts the total number of items in the underlying data source
+        /// and return true if the number of items == 0
+        /// </summary>
+        /// <typeparam name="TObject">The type of the object.</typeparam>
+        /// <typeparam name="TKey">The type of the key.</typeparam>
+        /// <param name="source">The source.</param>
+        /// <returns></returns>
+        public static IObservable<bool> IsEmpty<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source)
+        {
+            return source.ForAggregation()
+                .Count()
+                .StartWith(0)
+                .Select(count => count == 0);
+        }
+
+        /// <summary>
+        /// Counts the total number of items in the underlying data source
+        /// and returns true if the number of items is greater than 0
+        /// </summary>
+        /// <typeparam name="TObject">The type of the object.</typeparam>
+        /// <typeparam name="TKey">The type of the key.</typeparam>
+        /// <param name="source">The source.</param>
+        /// <returns></returns>
+        public static IObservable<bool> NotEmpty<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source)
+        {
+            return source.ForAggregation()
+                .Count()
+                .StartWith(0)
+                .Select(count => count > 0);
+        }
+
+        /// <summary>
+        /// Counts the total number of items in the underlying data source
+        /// and return true if the number of items == 0
+        /// </summary>
+        /// <typeparam name="TObject">The type of the object.</typeparam>
+        /// <param name="source">The source.</param>
+        /// <returns></returns>
+        public static IObservable<bool> IsEmpty<TObject>(this IObservable<IChangeSet<TObject>> source)
+        {
+            return source.ForAggregation()
+                .Count()
+                .StartWith(0)
+                .Select(count => count == 0);
+        }
+
+        /// <summary>
+        /// Counts the total number of items in the underlying data source
+        /// and returns true if the number of items is greater than 0
+        /// </summary>
+        /// <typeparam name="TObject">The type of the object.</typeparam>
+        /// <param name="source">The source.</param>
+        /// <returns></returns>
+        public static IObservable<bool> NotEmpty<TObject>(this IObservable<IChangeSet<TObject>> source)
+        {
+            return source.ForAggregation()
+                .Count()
+                .StartWith(0)
+                .Select(count => count > 0);
         }
     }
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

It adds overloads to check if the underlying collection has items or not.

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

The same functionality can be achieved by doing 
```collection.Connect().Count().Select(count => count == 0) ```

**What is the new behavior?**
<!-- If this is a feature change -->

The new overload adds these two overloads
```collection.Connect().IsEmpty() ```
```collection.Connect().NotEmpty()```

**What might this PR break?**

Nothing as far as I can see

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

