### PR TITLE
Correct handling of previous value on replace change in Combiner

### DIFF
--- a/src/DynamicData.Tests/List/OrFixture.cs
+++ b/src/DynamicData.Tests/List/OrFixture.cs
@@ -45,6 +45,30 @@ namespace DynamicData.Tests.List
         }
     }
 
+    public class OrReplaceFixture
+    {
+        [Fact]
+        public void ItemIsReplaced()
+        {
+            var item1 = new Item("A");
+            var item2 = new Item("B");
+            var item1Replacement = new Item("Test");
+
+            SourceList<Item> source1 = new SourceList<Item>();
+            source1.Add(item1);
+            SourceList<Item> source2 = new SourceList<Item>();
+            source2.Add(item2);
+
+            var list = new List<IObservable<IChangeSet<Item>>> { source1.Connect(), source2.Connect() };
+            var results = list.Or().AsAggregator();
+            source1.ReplaceAt(0, item1Replacement);
+
+            results.Data.Count.Should().Be(2);
+            results.Messages.Count.Should().Be(3);
+            results.Data.Items.Should().BeEquivalentTo(item1Replacement, item2);
+        }
+    }
+
     public abstract class OrFixtureBase: IDisposable
     {
         protected ISourceList<int> _source1;


### PR DESCRIPTION
**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
This fixes #251.

**What is the current behavior?**
When a value is replaced, no checks are run on the old value to see if it should remain in the list.

**What is the new behavior?**
When a replace change is encountered, both the new and the old value are checked.

**What might this PR break?**
Shouldn't break anything as this is fixes incorrect behavior.

**Please check if the PR fulfills these requirements**
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

