### PR TITLE
Fix handling of refresh and replace changes in DynamicCombiner

### DIFF
--- a/src/DynamicData.Tests/List/DynamicXOrFixture.cs
+++ b/src/DynamicData.Tests/List/DynamicXOrFixture.cs
@@ -99,7 +99,7 @@ namespace DynamicData.Tests.List
         }
 
         [Fact]
-        public void OverlappingRangeExludesInteresct()
+        public void OverlappingRangeExcludesIntersect()
         {
             _source.Add(_source1.Connect());
             _source.Add(_source2.Connect());


### PR DESCRIPTION
**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
This is a bug fix, very similar to PR #252 and PR #236, but for the DynamicCombiner.

**What is the current behavior?**
<!-- You can also link to an open issue here. -->
Refresh and replace changes are not correctly handled by the DynamicCombiner. Refreshes are not passed through, and the previous value in a replace is not updated.

**What is the new behavior?**
<!-- If this is a feature change -->
Refreshes are passed through, previous values in a replace are updated (added/removed if needed)

**What might this PR break?**
Shouldn't break anything as this is fixes incorrect behavior.

**Please check if the PR fulfills these requirements**
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


