### PR TITLE
housekeeping: Bump Microsoft.CodeAnalysis.FxCopAnalyzers from 2.9.3 to 2.9.4

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -60,7 +60,7 @@
 
   <ItemGroup Condition="!$(IsTestProject) AND !$(IsBenchmarkProject)">
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.3" PrivateAssets="all" />
-    <PackageReference Condition="'$(OS)' == 'Windows_NT'" Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.3" PrivateAssets="all" />
+    <PackageReference Condition="'$(OS)' == 'Windows_NT'" Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.4" PrivateAssets="all" />
     <PackageReference Include="Roslynator.Analyzers" Version="2.1.0" PrivateAssets="All" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Increases the version.

At the moment it's separated off for 2.6.3 for the Mac build.