### PR TITLE
BufferIf:  Adjusted API to not collide

### DIFF
--- a/src/DynamicData/List/ObservableListEx.cs
+++ b/src/DynamicData/List/ObservableListEx.cs
@@ -1713,7 +1713,7 @@ namespace DynamicData
         /// <exception cref="System.ArgumentNullException">source</exception>
         public static IObservable<IChangeSet<T>> BufferIf<T>([NotNull] this IObservable<IChangeSet<T>> source,
             [NotNull] IObservable<bool> pauseIfTrueSelector,
-            bool intialPauseState = false,
+            bool intialPauseState,
             IScheduler scheduler = null)
         {
             if (source == null)
@@ -1742,7 +1742,7 @@ namespace DynamicData
         /// <exception cref="System.ArgumentNullException">source</exception>
         public static IObservable<IChangeSet<T>> BufferIf<T>(this IObservable<IChangeSet<T>> source,
             IObservable<bool> pauseIfTrueSelector,
-            TimeSpan? timeOut = null,
+            TimeSpan? timeOut,
             IScheduler scheduler = null)
         {
             return BufferIf(source, pauseIfTrueSelector, false, timeOut, scheduler);
@@ -1762,8 +1762,8 @@ namespace DynamicData
         /// <exception cref="System.ArgumentNullException">source</exception>
         public static IObservable<IChangeSet<T>> BufferIf<T>(this IObservable<IChangeSet<T>> source,
             IObservable<bool> pauseIfTrueSelector,
-            bool intialPauseState = false,
-            TimeSpan? timeOut = null,
+            bool intialPauseState,
+            TimeSpan? timeOut,
             IScheduler scheduler = null)
         {
             if (source == null)


### PR DESCRIPTION
If only a pause observable was provided, the method signatures were ambiguous

**What kind of change does this PR introduce?**
API improvement to avoid ambiguous calls for BufferIf

**What is the current behavior?**
If BufferIf is called with only a pause observable provided, the compiler complains about ambiguous calls.



**What is the new behavior?**
Happy compiler



**What might this PR break?**
I don't think it will break much, as any users of those extra parameters will still see them as API options.  This should only improve users of BufferIf that only provide a pause observable.


**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

