### PR TITLE
Buffer if clearing fix

### DIFF
--- a/src/DynamicData/List/Internal/BufferIf.cs
+++ b/src/DynamicData/List/Internal/BufferIf.cs
@@ -72,7 +72,7 @@ namespace DynamicData.List.Internal
                                                        }
 
                                                        observer.OnNext(new ChangeSet<T>(buffer));
-                                                       buffer.Clear();
+                                                       buffer = new List<Change<T>>();
 
                                                        //kill off timeout if required
                                                        timeoutSubscriber.Disposable = Disposable.Empty;

--- a/src/DynamicData/List/ObservableListEx.cs
+++ b/src/DynamicData/List/ObservableListEx.cs
@@ -1713,7 +1713,7 @@ namespace DynamicData
         /// <exception cref="System.ArgumentNullException">source</exception>
         public static IObservable<IChangeSet<T>> BufferIf<T>([NotNull] this IObservable<IChangeSet<T>> source,
             [NotNull] IObservable<bool> pauseIfTrueSelector,
-            bool intialPauseState = false,
+            bool intialPauseState,
             IScheduler scheduler = null)
         {
             if (source == null)
@@ -1742,7 +1742,7 @@ namespace DynamicData
         /// <exception cref="System.ArgumentNullException">source</exception>
         public static IObservable<IChangeSet<T>> BufferIf<T>(this IObservable<IChangeSet<T>> source,
             IObservable<bool> pauseIfTrueSelector,
-            TimeSpan? timeOut = null,
+            TimeSpan? timeOut,
             IScheduler scheduler = null)
         {
             return BufferIf(source, pauseIfTrueSelector, false, timeOut, scheduler);
@@ -1762,8 +1762,8 @@ namespace DynamicData
         /// <exception cref="System.ArgumentNullException">source</exception>
         public static IObservable<IChangeSet<T>> BufferIf<T>(this IObservable<IChangeSet<T>> source,
             IObservable<bool> pauseIfTrueSelector,
-            bool intialPauseState = false,
-            TimeSpan? timeOut = null,
+            bool intialPauseState,
+            TimeSpan? timeOut,
             IScheduler scheduler = null)
         {
             if (source == null)


### PR DESCRIPTION
**What kind of change does this PR introduce?**
A hopeful fix for ObservableList BufferIf usage being more reliable downstream, especially when used /w delaying calls like ObserveOn.

The change makes a new list for the internal buffer when firing, rather than reusing the same list that was provided to ChangeSet.


**What is the current behavior?**
Current behavior reuses the same internal buffer list for the outgoing ChangeSet that it is firing.  This meant that the subsequent Clear() call on the buffer list would clear the ChangeSet as well, as it was the same list.  This only became a problem if the ChangeSet consumption was delayed by an ObserveOn call or something similar.


**What is the new behavior?**
When executing an event, it passes the internal buffer to the ChangeSet to be used directly.  A new list is then created for the internal buffer variable to be filled with new data.

An alternate route could have been constructing a new list and copying over the buffer's data to be given to the ChangeSet, and then clearing the buffer.  The current setup felt like less processing with the same results.


**What might this PR break?**
ObservableList BufferIf calls in general.  Might not be a full fix for all possible threading scenarios.  Might be some oddball edge cases not yet considered.


**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)