### PR TITLE
IObservableList implements IReadOnlyList.  ISourceList implements IList

### DIFF
--- a/src/DynamicData/Cache/ObservableCacheEx.cs
+++ b/src/DynamicData/Cache/ObservableCacheEx.cs
@@ -2195,6 +2195,24 @@ namespace DynamicData
         }
 
         /// <summary>
+        /// Dynamically apply a logical And operator between the items in the outer source list.
+        /// Items which are in all of the sources are included in the result
+        /// </summary>
+        /// <typeparam name="TObject">The type of the object.</typeparam>
+        /// <typeparam name="TKey">The type of the key.</typeparam>
+        /// <param name="sources">The source.</param>
+        /// <returns></returns>
+        public static IObservable<IChangeSet<TObject, TKey>> And<TObject, TKey>(this ISourceList<IObservable<IChangeSet<TObject, TKey>>> sources)
+        {
+            if (sources == null)
+            {
+                throw new ArgumentNullException(nameof(sources));
+            }
+
+            return And((IObservableList<IObservable<IChangeSet<TObject, TKey>>>)sources);
+        }
+
+        /// <summary>
         /// Dynamically apply a logical And operator between the items in the outer observable list.
         /// Items which are in all of the sources are included in the result
         /// </summary>
@@ -2297,6 +2315,24 @@ namespace DynamicData
             }
 
             return sources.Combine(CombineOperator.Or);
+        }
+
+        /// <summary>
+        /// Dynamically apply a logical Or operator between the items in the outer source list.
+        /// Items which are in any of the sources are included in the result
+        /// </summary>
+        /// <typeparam name="TObject">The type of the object.</typeparam>
+        /// <typeparam name="TKey">The type of the key.</typeparam>
+        /// <param name="sources">The source.</param>
+        /// <returns></returns>
+        public static IObservable<IChangeSet<TObject, TKey>> Or<TObject, TKey>(this ISourceList<IObservable<IChangeSet<TObject, TKey>>> sources)
+        {
+            if (sources == null)
+            {
+                throw new ArgumentNullException(nameof(sources));
+            }
+
+            return Or((IObservableList<IObservable<IChangeSet<TObject, TKey>>>)sources);
         }
 
         //public static IObservable<IChangeSet<TDestination, TDestinationKey>> Or<TDestination, TDestinationKey, TSource, TSourceKey>(this IObservable<IObservableCache<TSource, TSourceKey>> source,
@@ -2432,6 +2468,24 @@ namespace DynamicData
         }
 
         /// <summary>
+        /// Dynamically apply a logical Xor operator between the items in the outer source list.
+        /// Items which are only in one of the sources are included in the result
+        /// </summary>
+        /// <typeparam name="TObject">The type of the object.</typeparam>
+        /// <typeparam name="TKey">The type of the key.</typeparam>
+        /// <param name="sources">The source.</param>
+        /// <returns></returns>
+        public static IObservable<IChangeSet<TObject, TKey>> Xor<TObject, TKey>(this ISourceList<IObservable<IChangeSet<TObject, TKey>>> sources)
+        {
+            if (sources == null)
+            {
+                throw new ArgumentNullException(nameof(sources));
+            }
+
+            return Xor((IObservableList<IObservable<IChangeSet<TObject, TKey>>>)sources);
+        }
+
+        /// <summary>
         /// Dynamically apply a logical Xor operator between the items in the outer observable list.
         /// Items which are in any of the sources are included in the result
         /// </summary>
@@ -2536,6 +2590,24 @@ namespace DynamicData
             }
 
             return sources.Combine(CombineOperator.Except);
+        }
+
+        /// <summary>
+        /// Dynamically apply a logical Except operator between the collections 
+        /// Items from the first collection in the outer list are included unless contained in any of the other lists
+        /// </summary>
+        /// <typeparam name="TObject">The type of the object.</typeparam>
+        /// <typeparam name="TKey">The type of the key.</typeparam>
+        /// <param name="sources">The source.</param>
+        /// <returns></returns>
+        public static IObservable<IChangeSet<TObject, TKey>> Except<TObject, TKey>(this ISourceList<IObservable<IChangeSet<TObject, TKey>>> sources)
+        {
+            if (sources == null)
+            {
+                throw new ArgumentNullException(nameof(sources));
+            }
+
+            return Except((IObservableList<IObservable<IChangeSet<TObject, TKey>>>)sources);
         }
 
         /// <summary>

--- a/src/DynamicData/List/IObservableList.cs
+++ b/src/DynamicData/List/IObservableList.cs
@@ -12,7 +12,7 @@ namespace DynamicData
     /// A readonly observable list, providing  observable methods
     /// as well as data access methods
     /// </summary>
-    public interface IObservableList<T> : IDisposable
+    public interface IObservableList<T> : IReadOnlyList<T>, IDisposable
     {
         /// <summary>
         /// Connect to the observable list and observe any changes
@@ -37,10 +37,5 @@ namespace DynamicData
         /// Items enumerable
         /// </summary>
         IEnumerable<T> Items { get; }
-
-        /// <summary>
-        /// Gets the count.
-        /// </summary>
-        int Count { get; }
     }
 }

--- a/src/DynamicData/List/ISourceList.cs
+++ b/src/DynamicData/List/ISourceList.cs
@@ -26,23 +26,12 @@ namespace DynamicData
         /// </summary>
         new int Count { get; }
 
-        //
-        // Summary:
-        //     Gets or sets the element at the specified index.
-        //
-        // Parameters:
-        //   index:
-        //     The zero-based index of the element to get or set.
-        //
-        // Returns:
-        //     The element at the specified index.
-        //
-        // Exceptions:
-        //   T:System.ArgumentOutOfRangeException:
-        //     index is not a valid index in the ISourceList`1.
-        //
-        //   T:System.NotSupportedException:
-        //     The property is set and the ISourceList`1 is read-only.
+        /// <summary>
+        /// Gets or sets the element at the specified index.
+        /// </summary>
+        /// <param name="index">The zero-based index of the element to get or set.</param>
+        /// <exception cref="System.ArgumentOutOfRangeException">index is not a valid index in the ISourceList`1.</exception>
+        /// <exception cref="System.NotSupportedException">The property is set and the ISourceList`1 is read-only.</exception>
         new T this[int index] { get; set; }
     }
 }

--- a/src/DynamicData/List/ISourceList.cs
+++ b/src/DynamicData/List/ISourceList.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 
 // ReSharper disable once CheckNamespace
 namespace DynamicData
@@ -12,12 +13,36 @@ namespace DynamicData
     /// as well as data access methods
     /// </summary>
     /// <typeparam name="T"></typeparam>
-    public interface ISourceList<T> : IObservableList<T>
+    public interface ISourceList<T> : IObservableList<T>, IList<T>
     {
         /// <summary>
         /// Edit the inner list within the list's internal locking mechanism
         /// </summary>
         /// <param name="updateAction">The update action.</param>
         void Edit(Action<IExtendedList<T>> updateAction);
+
+        /// <summary>
+        /// Gets the count.
+        /// </summary>
+        new int Count { get; }
+
+        //
+        // Summary:
+        //     Gets or sets the element at the specified index.
+        //
+        // Parameters:
+        //   index:
+        //     The zero-based index of the element to get or set.
+        //
+        // Returns:
+        //     The element at the specified index.
+        //
+        // Exceptions:
+        //   T:System.ArgumentOutOfRangeException:
+        //     index is not a valid index in the ISourceList`1.
+        //
+        //   T:System.NotSupportedException:
+        //     The property is set and the ISourceList`1 is read-only.
+        new T this[int index] { get; set; }
     }
 }

--- a/src/DynamicData/List/Internal/AnonymousObservableList.cs
+++ b/src/DynamicData/List/Internal/AnonymousObservableList.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 
 namespace DynamicData.List.Internal
@@ -26,6 +27,8 @@ namespace DynamicData.List.Internal
             _sourceList = sourceList ?? throw new ArgumentNullException(nameof(sourceList));
         }
 
+        public T this[int index] => _sourceList[index];
+
         public IObservable<int> CountChanged => _sourceList.CountChanged;
 
         public IEnumerable<T> Items => _sourceList.Items;
@@ -37,5 +40,9 @@ namespace DynamicData.List.Internal
         public IObservable<IChangeSet<T>> Preview(Func<T, bool> predicate = null) => _sourceList.Preview(predicate);
 
         public void Dispose() => _sourceList.Dispose();
+
+        public IEnumerator<T> GetEnumerator() => _sourceList.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => _sourceList.GetEnumerator();
     }
 }

--- a/src/DynamicData/List/Internal/ReaderWriter.cs
+++ b/src/DynamicData/List/Internal/ReaderWriter.cs
@@ -123,6 +123,18 @@ namespace DynamicData.List.Internal
             }
         }
 
+        public T this[int index]
+        {
+            get
+            {
+                lock (_locker)
+                {
+                    return _data[index];
+                }
+            }
+        }
+
+
         public int Count
         {
             get
@@ -131,6 +143,22 @@ namespace DynamicData.List.Internal
                 {
                     return _data.Count;
                 }
+            }
+        }
+
+        public bool Contains(T item)
+        {
+            lock (_locker)
+            {
+                return _data.Contains(item);
+            }
+        }
+
+        public void CopyTo(T[] array, int arrayIndex)
+        {
+            lock (_locker)
+            {
+                _data.CopyTo(array, arrayIndex);
             }
         }
     }

--- a/src/DynamicData/List/Internal/ReaderWriter.cs
+++ b/src/DynamicData/List/Internal/ReaderWriter.cs
@@ -161,5 +161,13 @@ namespace DynamicData.List.Internal
                 _data.CopyTo(array, arrayIndex);
             }
         }
+
+        public int IndexOf(T item)
+        {
+            lock (_locker)
+            {
+                return _data.IndexOf(item);
+            }
+        }
     }
 }

--- a/src/DynamicData/List/ObservableListEx.cs
+++ b/src/DynamicData/List/ObservableListEx.cs
@@ -2121,6 +2121,19 @@ namespace DynamicData
         }
 
         /// <summary>
+        /// Dynamically apply a logical Or operator between the items in the outer source list.
+        /// Items which are in any of the sources are included in the result
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="sources">The source.</param>
+        /// <returns></returns>
+        public static IObservable<IChangeSet<T>> Or<T>(
+            [NotNull] this ISourceList<IObservable<IChangeSet<T>>> sources)
+        {
+            return Or((IObservableList<IObservable<IChangeSet<T>>>)sources);
+        }
+
+        /// <summary>
         /// Dynamically apply a logical Or operator between the items in the outer observable list.
         /// Items which are in any of the sources are included in the result
         /// </summary>
@@ -2184,6 +2197,19 @@ namespace DynamicData
         }
 
         /// <summary>
+        /// Dynamically apply a logical Xor operator between the items in the outer source list.
+        /// Items which are in any of the sources are included in the result
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="sources">The source.</param>
+        /// <returns></returns>
+        public static IObservable<IChangeSet<T>> Xor<T>(
+            [NotNull] this ISourceList<IObservable<IChangeSet<T>>> sources)
+        {
+            return Xor((IObservableList<IObservable<IChangeSet<T>>>)sources);
+        }
+
+        /// <summary>
         /// Dynamically apply a logical Xor operator between the items in the outer observable list.
         /// Items which are in any of the sources are included in the result
         /// </summary>
@@ -2219,6 +2245,19 @@ namespace DynamicData
             params IObservable<IChangeSet<T>>[] others)
         {
             return source.Combine(CombineOperator.And, others);
+        }
+
+        /// <summary>
+        /// Dynamically apply a logical And operator between the items in the outer source list.
+        /// Items which are in any of the sources are included in the result
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="sources">The source.</param>
+        /// <returns></returns>
+        public static IObservable<IChangeSet<T>> And<T>(
+            [NotNull] this ISourceList<IObservable<IChangeSet<T>>> sources)
+        {
+            return And((IObservableList<IObservable<IChangeSet<T>>>)sources);
         }
 
         /// <summary>
@@ -2295,6 +2334,19 @@ namespace DynamicData
             [NotNull] this ICollection<IObservable<IChangeSet<T>>> sources)
         {
             return sources.Combine(CombineOperator.Except);
+        }
+
+        /// <summary>
+        /// Apply a logical Except operator between the collections.
+        /// Items which are in the source and not in the others are included in the result
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="sources">The sources.</param>
+        /// <returns></returns>>
+        public static IObservable<IChangeSet<T>> Except<T>(
+            [NotNull] this ISourceList<IObservable<IChangeSet<T>>> sources)
+        {
+            return Except((IObservableList<IObservable<IChangeSet<T>>>)sources);
         }
 
         /// <summary>

--- a/src/DynamicData/List/SourceList.cs
+++ b/src/DynamicData/List/SourceList.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
@@ -26,7 +27,6 @@ namespace DynamicData
         private readonly IDisposable _cleanUp;
         private readonly object _locker = new object();
         private readonly object _writeLock = new object();
-
         private int _editLevel;
 
         /// <summary>
@@ -150,6 +150,19 @@ namespace DynamicData
         /// <inheritdoc />
         public int Count => _readerWriter.Count;
 
+        /// <inheritdoc /> 
+        public T this[int index]
+        {
+            get => _readerWriter[index];
+            set
+            {
+                this.Edit((list) =>
+                {
+                    list[index] = value;
+                });
+            }
+        }
+
         /// <inheritdoc />
         public IObservable<int> CountChanged => _countChanged.Value.StartWith(_readerWriter.Count).DistinctUntilChanged();
 
@@ -199,5 +212,66 @@ namespace DynamicData
             _cleanUp.Dispose();
             _changesPreview?.Dispose();
         }
+
+        /// <inheritdoc /> 
+        public IEnumerator<T> GetEnumerator()
+        {
+            return this.Items.GetEnumerator();
+        }
+
+        /// <inheritdoc /> 
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return this.GetEnumerator();
+        }
+
+        /// <inheritdoc /> 
+        public int IndexOf(T item)
+        {
+            return this.IndexOf(item);
+        }
+
+        /// <inheritdoc /> 
+        public bool Contains(T item)
+        {
+            return this._readerWriter.Contains(item);
+        }
+
+        /// <inheritdoc /> 
+        public void CopyTo(T[] array, int arrayIndex)
+        {
+            this._readerWriter.CopyTo(array, arrayIndex);
+        }
+
+        #region Hidden IList Implementations 
+        bool ICollection<T>.IsReadOnly => false;
+
+        T IReadOnlyList<T>.this[int index] => this[index];
+
+        void IList<T>.Insert(int index, T item)
+        {
+            this.Insert(index, item);
+        }
+
+        void IList<T>.RemoveAt(int index)
+        {
+            this.RemoveAt(index);
+        }
+
+        void ICollection<T>.Add(T item)
+        {
+            this.Add(item);
+        }
+
+        void ICollection<T>.Clear()
+        {
+            this.Clear();
+        }
+
+        bool ICollection<T>.Remove(T item)
+        {
+            return this.Remove(item);
+        }
+        #endregion
     }
 }

--- a/src/DynamicData/List/SourceList.cs
+++ b/src/DynamicData/List/SourceList.cs
@@ -214,64 +214,40 @@ namespace DynamicData
         }
 
         /// <inheritdoc /> 
-        public IEnumerator<T> GetEnumerator()
-        {
-            return this.Items.GetEnumerator();
-        }
+        public IEnumerator<T> GetEnumerator() => this.Items.GetEnumerator();
 
         /// <inheritdoc /> 
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return this.GetEnumerator();
-        }
+        IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
 
         /// <inheritdoc /> 
-        public int IndexOf(T item)
-        {
-            return this.IndexOf(item);
-        }
+        public int IndexOf(T item) => this._readerWriter.IndexOf(item);
 
         /// <inheritdoc /> 
-        public bool Contains(T item)
-        {
-            return this._readerWriter.Contains(item);
-        }
+        public bool Contains(T item) => this._readerWriter.Contains(item);
 
         /// <inheritdoc /> 
-        public void CopyTo(T[] array, int arrayIndex)
+        public void CopyTo(T[] array, int arrayIndex) => this._readerWriter.CopyTo(array, arrayIndex);
+
+        /// <inheritdoc />
+        public void Insert(int index, T item) => this.Edit(list => list.Insert(index, item));
+
+        /// <inheritdoc />
+        public void RemoveAt(int index) => this.Edit(list => list.RemoveAt(index));
+
+        /// <inheritdoc />
+        public void Add(T item) => this.Edit(list => list.Add(item));
+
+        /// <inheritdoc />
+        public void Clear() => this.Edit(list => list.Clear());
+
+        /// <inheritdoc />
+        public bool Remove(T item)
         {
-            this._readerWriter.CopyTo(array, arrayIndex);
+            bool removed = false;
+            this.Edit(list => removed = list.Remove(item));
+            return removed;
         }
 
-        #region Hidden IList Implementations 
         bool ICollection<T>.IsReadOnly => false;
-
-        T IReadOnlyList<T>.this[int index] => this[index];
-
-        void IList<T>.Insert(int index, T item)
-        {
-            this.Insert(index, item);
-        }
-
-        void IList<T>.RemoveAt(int index)
-        {
-            this.RemoveAt(index);
-        }
-
-        void ICollection<T>.Add(T item)
-        {
-            this.Add(item);
-        }
-
-        void ICollection<T>.Clear()
-        {
-            this.Clear();
-        }
-
-        bool ICollection<T>.Remove(T item)
-        {
-            return this.Remove(item);
-        }
-        #endregion
     }
 }

--- a/src/DynamicData/List/SourceListEditConvenienceEx.cs
+++ b/src/DynamicData/List/SourceListEditConvenienceEx.cs
@@ -43,54 +43,6 @@ namespace DynamicData
         }
 
         /// <summary>
-        /// Clears all items from the specified source list
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="source">The source.</param>
-        public static void Clear<T>([NotNull] this ISourceList<T> source)
-        {
-            if (source == null)
-            {
-                throw new ArgumentNullException(nameof(source));
-            }
-
-            source.Edit(list => list.Clear());
-        }
-
-        /// <summary>
-        /// Adds the specified item to the source list
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="source">The source.</param>
-        /// <param name="item">The item.</param>
-        public static void Add<T>([NotNull] this ISourceList<T> source, T item)
-        {
-            if (source == null)
-            {
-                throw new ArgumentNullException(nameof(source));
-            }
-
-            source.Edit(list => list.Add(item));
-        }
-
-        /// <summary>
-        /// Adds the specified item to the source list
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="source">The source.</param>
-        /// <param name="item">The item.</param>
-        /// <param name="index">The index.</param>
-        public static void Insert<T>([NotNull] this ISourceList<T> source, int index, T item)
-        {
-            if (source == null)
-            {
-                throw new ArgumentNullException(nameof(source));
-            }
-
-            source.Edit(list => list.Insert(index, item));
-        }
-
-        /// <summary>
         /// Adds the specified items to the source list
         /// </summary>
         /// <typeparam name="T"></typeparam>
@@ -121,24 +73,6 @@ namespace DynamicData
             }
 
             source.Edit(list => list.AddRange(items, index));
-        }
-
-        /// <summary>
-        /// Removes the specified item from the source list
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="source">The source.</param>
-        /// <param name="item">The item.</param>
-        public static bool Remove<T>([NotNull] this ISourceList<T> source, T item)
-        {
-            bool removed = false;
-            if (source == null)
-            {
-                throw new ArgumentNullException(nameof(source));
-            }
-
-            source.Edit(list => removed = list.Remove(item));
-            return removed;
         }
 
         /// <summary>
@@ -191,22 +125,6 @@ namespace DynamicData
             }
 
             source.Edit(list => list.RemoveRange(index, count));
-        }
-
-        /// <summary>
-        /// Removes the element at the specified index
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="source">The source.</param>
-        /// <param name="index">The index.</param>
-        public static void RemoveAt<T>([NotNull] this ISourceList<T> source, int index)
-        {
-            if (source == null)
-            {
-                throw new ArgumentNullException(nameof(source));
-            }
-
-            source.Edit(list => list.RemoveAt(index));
         }
 
         /// <summary>


### PR DESCRIPTION
**What kind of change does this PR introduce?**
IObservableList implements IReadOnlyList.  ISourceList implements IList.

I find that I write a lot of convenience code via extension methods, and I try to hook them onto the most generic objects that I can.  These would be functions similar to the ones found in DynamicData itself like `ListEx.AddRange(this IList<T> source, IEnumerable<T> items)`;

Because DynamicData's list functionality didn't inherit from the List interfaces meant its collections didn't hook onto those extension methods.  I had to duplicate the code for them to work with DynamicData, which is verbose and hindered refactorability as both versions needed to be maintained with the same updates.

I didn't see anything glaring as to why DynamicData's lists couldn't implement the interfaces, so I gave it a stab that seems to have worked out alright for my fork, so I thought I'd migrate it upwards for everyone else.

**What is the current behavior?**
SourceList and its interfaces implement list patterns, without actually implementing IList<T>/IReadOnlyList<T>

**What is the new behavior?**
SourceList and its interfaces implement IList<T>/IReadOnlyList<T>


**What might this PR break?**
This could break wiring that currently works around the fact that SourceList doesn't implement IList.  I had to do a bit of maintenance myself on ObservableListEx, for example, adding another extension method that took ISourceList directly to clear the ambiguous call between the `IObservable<IChangeSet<T>>` and ` ICollection<IObservable<IChangeSet<T>>>` versions.

I believe I've handled all the cases in DynamicData itself, but users of the library might have made their own workarounds for the lack of IList that might need to be adjusted or dialed back.

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:
I ran the unit tests, which passed.  I couldn't think of any obvious unit tests to add, but let me know if anyone thinks of some we could write to flex any of the new behavior.