### PR TITLE
Reduced some extra ChangeSet instantiations + content copies

### DIFF
--- a/src/DynamicData/List/ChangeAwareList.cs
+++ b/src/DynamicData/List/ChangeAwareList.cs
@@ -21,7 +21,7 @@ namespace DynamicData
     {
         private readonly object _lockObject = new object();
         private readonly List<T> _innerList;
-        private List<Change<T>> _changes = new List<Change<T>>();
+        private ChangeSet<T> _changes = new ChangeSet<T>();
 
         /// <summary>
         /// Create a change aware list with the specified capacity
@@ -67,7 +67,7 @@ namespace DynamicData
 
             if (copyChanges)
             {
-                _changes = new List<Change<T>>(list._changes);
+                _changes = new ChangeSet<T>(list._changes);
             }
         }
 
@@ -84,7 +84,7 @@ namespace DynamicData
                     return ChangeSet<T>.Empty;
                 }
 
-                returnValue = new ChangeSet<T>(_changes);
+                returnValue = _changes;
 
                 //we can infer this is a Clear
                 if (_innerList.Count == 0 && returnValue.Removes == returnValue.TotalChanges && returnValue.TotalChanges > 1)
@@ -106,7 +106,7 @@ namespace DynamicData
         {
             lock (_lockObject)
             {
-                _changes = new List<Change<T>>();
+                _changes = new ChangeSet<T>();
             }
         }
 

--- a/src/DynamicData/List/ChangeAwareList.cs
+++ b/src/DynamicData/List/ChangeAwareList.cs
@@ -92,9 +92,9 @@ namespace DynamicData
                     var removed = returnValue.Unified().Select(u => u.Current);
                     returnValue = new ChangeSet<T> { new Change<T>(ListChangeReason.Clear, removed) };
                 }
-            }
 
-            ClearChanges();
+                ClearChanges();
+            }
 
             return returnValue;
         }

--- a/src/DynamicData/List/Internal/BufferIf.cs
+++ b/src/DynamicData/List/Internal/BufferIf.cs
@@ -38,7 +38,7 @@ namespace DynamicData.List.Internal
                     {
                         var locker = new object();
                         var paused = _initialPauseState;
-                        var buffer = new List<Change<T>>();
+                        var buffer = new ChangeSet<T>();
                         var timeoutSubscriber = new SerialDisposable();
                         var timeoutSubject = new Subject<bool>();
 
@@ -71,8 +71,8 @@ namespace DynamicData.List.Internal
                                                            return;
                                                        }
 
-                                                       observer.OnNext(new ChangeSet<T>(buffer));
-                                                       buffer = new List<Change<T>>();
+                                                       observer.OnNext(buffer);
+                                                       buffer = new ChangeSet<T>();
 
                                                        //kill off timeout if required
                                                        timeoutSubscriber.Disposable = Disposable.Empty;

--- a/src/DynamicData/List/Internal/TransformMany.cs
+++ b/src/DynamicData/List/Internal/TransformMany.cs
@@ -101,7 +101,7 @@ namespace DynamicData.List.Internal
                 return _source.Transform(item => new ManyContainer(_manyselector(item).ToArray()), true)
                     .Select(changes =>
                     {
-                        var destinationChanges = new ChangeSet<TDestination>(new DestinationEnumerator(changes, _equalityComparer));
+                        var destinationChanges = new DestinationEnumerator(changes, _equalityComparer);
                         result.Clone(destinationChanges, _equalityComparer);
                         return result.CaptureChanges();
                     })

--- a/src/DynamicData/List/ListEx.cs
+++ b/src/DynamicData/List/ListEx.cs
@@ -63,6 +63,23 @@ namespace DynamicData
         /// </exception>
         public static void Clone<T>(this IList<T> source, IChangeSet<T> changes, IEqualityComparer<T> equalityComparer)
         {
+            Clone(source, (IEnumerable<Change<T>>)changes, equalityComparer);
+        }
+
+        /// <summary> 
+        /// Clones the list from the specified enumerable of changes 
+        /// </summary> 
+        /// <typeparam name="T"></typeparam> 
+        /// <param name="source">The source.</param> 
+        /// <param name="changes">The changes.</param> 
+        /// <param name="equalityComparer">An equality comparer to match items in the changes.</param> 
+        /// <exception cref="System.ArgumentNullException"> 
+        /// source 
+        /// or 
+        /// changes 
+        /// </exception> 
+        public static void Clone<T>(this IList<T> source, IEnumerable<Change<T>> changes, IEqualityComparer<T> equalityComparer)
+        {
             if (source == null)
             {
                 throw new ArgumentNullException(nameof(source));

--- a/src/DynamicData/List/ObservableListEx.cs
+++ b/src/DynamicData/List/ObservableListEx.cs
@@ -408,8 +408,7 @@ namespace DynamicData
         {
             return source.Select(changes =>
             {
-                var items = changes.Transform(t => (object)t);
-                return new ChangeSet<object>(items);
+                return changes.Transform(t => (object)t);
             });
         }
 

--- a/src/DynamicData/List/SourceList.cs
+++ b/src/DynamicData/List/SourceList.cs
@@ -160,10 +160,13 @@ namespace DynamicData
             {
                 lock (_locker)
                 {
-                    var initial = new ChangeSet<T>(new[] {new Change<T>(ListChangeReason.AddRange, _readerWriter.Items)});
-                    if (initial.TotalChanges > 0)
+                    if (_readerWriter.Items.Length > 0)
                     {
-                        observer.OnNext(initial);
+                        observer.OnNext(
+                            new ChangeSet<T>()
+                            {
+                                new Change<T>(ListChangeReason.AddRange, _readerWriter.Items)
+                            });
                     }
 
                     var source = _changes.Finally(observer.OnCompleted);


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Cuts some extra instantiations and list copies. After ChangeSet was updated to be itself a List (#278), there was some room for potential optimizations. I did a find references on code that utilized the ChangeSet(IEnumerable<Change>) constructor, and looked very briefly around those areas for potential improvements. These are the half dozen I spotted that I thought were quick tweaks.

Edit:  I also moved a call to be inside a lock where it wasn't before.  See related comment

**What is the current behavior?**
Some code snippets created extra middlemen lists or changesets that were then passed to the final returning changeset.



**What is the new behavior?**
Code tries to avoid extra internal lists or copies by using ChangeSet's list functionality as directly as possible.

In the ChangeAwareList, during captures, the change to the locking should make it safer by ensuring the clear occurs after the capture before any other changes from another thread might occur.

**What might this PR break?**
Could always be a decent amount of regression bugs if there are some edge cases not considered in the refactors presented.

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:
I ran the unit tests, which passed. I did not write any new tests, as no new functionality was added. Only existing functionality was slightly optimized.
