### PR TITLE
Extend descriptions of ObservableChangeSet methods

### DIFF
--- a/src/DynamicData/Binding/BindingListEx.cs
+++ b/src/DynamicData/Binding/BindingListEx.cs
@@ -18,6 +18,7 @@ namespace DynamicData.Binding
     {
         /// <summary>
         /// Convert a binding list into an observable change set
+        /// Change set observes list change events
         /// </summary>
         /// <typeparam name="T">The type of the object.</typeparam>
         /// <param name="source">The source.</param>
@@ -35,6 +36,7 @@ namespace DynamicData.Binding
 
         /// <summary>
         /// Convert a binding list into an observable change set
+        /// Change set observes list change events
         /// </summary>
         /// <typeparam name="TObject">The type of the object.</typeparam>
         /// <typeparam name="TKey">The type of the key.</typeparam>
@@ -61,6 +63,7 @@ namespace DynamicData.Binding
 
         /// <summary>
         /// Convert a binding list into an observable change set
+        /// Change set observes list change events
         /// </summary>
         /// <typeparam name="T">The type of the object.</typeparam>
         /// <typeparam name="TCollection"></typeparam>

--- a/src/DynamicData/Binding/BindingListEx.cs
+++ b/src/DynamicData/Binding/BindingListEx.cs
@@ -17,8 +17,8 @@ namespace DynamicData.Binding
     public static class BindingListEx
     {
         /// <summary>
-        /// Convert a binding list into an observable change set
-        /// Change set observes list change events
+        /// Convert a binding list into an observable change set.
+        /// Change set observes list change events.
         /// </summary>
         /// <typeparam name="T">The type of the object.</typeparam>
         /// <param name="source">The source.</param>
@@ -35,8 +35,8 @@ namespace DynamicData.Binding
         }
 
         /// <summary>
-        /// Convert a binding list into an observable change set
-        /// Change set observes list change events
+        /// Convert a binding list into an observable change set.
+        /// Change set observes list change events.
         /// </summary>
         /// <typeparam name="TObject">The type of the object.</typeparam>
         /// <typeparam name="TKey">The type of the key.</typeparam>
@@ -62,8 +62,8 @@ namespace DynamicData.Binding
         }
 
         /// <summary>
-        /// Convert a binding list into an observable change set
-        /// Change set observes list change events
+        /// Convert a binding list into an observable change set.
+        /// Change set observes list change events.
         /// </summary>
         /// <typeparam name="T">The type of the object.</typeparam>
         /// <typeparam name="TCollection"></typeparam>

--- a/src/DynamicData/Binding/ObservableCollectionEx.cs
+++ b/src/DynamicData/Binding/ObservableCollectionEx.cs
@@ -19,6 +19,7 @@ namespace DynamicData.Binding
     {
         /// <summary>
         /// Convert an observable collection into an observable change set
+        /// Change set observes collection change events
         /// </summary>
         /// <typeparam name="T">The type of the object.</typeparam>
         /// <param name="source">The source.</param>
@@ -36,6 +37,7 @@ namespace DynamicData.Binding
 
         /// <summary>
         /// Convert an observable collection into an observable change set
+        /// Change set observes collection change events
         /// </summary>
         /// <typeparam name="TObject">The type of the object.</typeparam>
         /// <typeparam name="TKey">The type of the key.</typeparam>
@@ -62,6 +64,7 @@ namespace DynamicData.Binding
 
         /// <summary>
         /// Convert the readonly observable collection into an observable change set
+        /// Change set observes collection change events
         /// </summary>
         /// <typeparam name="T">The type of the object.</typeparam>
         /// <param name="source">The source.</param>
@@ -79,6 +82,7 @@ namespace DynamicData.Binding
 
         /// <summary>
         /// Convert the readonly observable collection into an observable change set
+        /// Change set observes collection change events
         /// </summary>
         /// <typeparam name="TObject">The type of the object.</typeparam>
         /// <typeparam name="TKey">The type of the key.</typeparam>
@@ -105,6 +109,7 @@ namespace DynamicData.Binding
 
         /// <summary>
         /// Convert an observable collection into an observable change set
+        /// Change set observes collection change events
         /// </summary>
         /// <typeparam name="T">The type of the object.</typeparam>
         /// <typeparam name="TCollection"></typeparam>

--- a/src/DynamicData/Binding/ObservableCollectionEx.cs
+++ b/src/DynamicData/Binding/ObservableCollectionEx.cs
@@ -18,8 +18,8 @@ namespace DynamicData.Binding
     public static class ObservableCollectionEx
     {
         /// <summary>
-        /// Convert an observable collection into an observable change set
-        /// Change set observes collection change events
+        /// Convert an observable collection into an observable change set.
+        /// Change set observes collection change events.
         /// </summary>
         /// <typeparam name="T">The type of the object.</typeparam>
         /// <param name="source">The source.</param>
@@ -36,8 +36,8 @@ namespace DynamicData.Binding
         }
 
         /// <summary>
-        /// Convert an observable collection into an observable change set
-        /// Change set observes collection change events
+        /// Convert an observable collection into an observable change set.
+        /// Change set observes collection change events.
         /// </summary>
         /// <typeparam name="TObject">The type of the object.</typeparam>
         /// <typeparam name="TKey">The type of the key.</typeparam>
@@ -63,8 +63,8 @@ namespace DynamicData.Binding
         }
 
         /// <summary>
-        /// Convert the readonly observable collection into an observable change set
-        /// Change set observes collection change events
+        /// Convert the readonly observable collection into an observable change set.
+        /// Change set observes collection change events.
         /// </summary>
         /// <typeparam name="T">The type of the object.</typeparam>
         /// <param name="source">The source.</param>
@@ -81,8 +81,8 @@ namespace DynamicData.Binding
         }
 
         /// <summary>
-        /// Convert the readonly observable collection into an observable change set
-        /// Change set observes collection change events
+        /// Convert the readonly observable collection into an observable change set.
+        /// Change set observes collection change events.
         /// </summary>
         /// <typeparam name="TObject">The type of the object.</typeparam>
         /// <typeparam name="TKey">The type of the key.</typeparam>
@@ -108,8 +108,8 @@ namespace DynamicData.Binding
         }
 
         /// <summary>
-        /// Convert an observable collection into an observable change set
-        /// Change set observes collection change events
+        /// Convert an observable collection into an observable change set.
+        /// Change set observes collection change events.
         /// </summary>
         /// <typeparam name="T">The type of the object.</typeparam>
         /// <typeparam name="TCollection"></typeparam>

--- a/src/DynamicData/Cache/ObservableCacheEx.cs
+++ b/src/DynamicData/Cache/ObservableCacheEx.cs
@@ -5077,6 +5077,7 @@ namespace DynamicData
 
         /// <summary>
         /// Converts the observable to an observable changeset
+        /// Change set observes observable change events
         /// </summary>
         /// <typeparam name="TObject">The type of the object.</typeparam>
         /// <typeparam name="TKey">The type of the key.</typeparam>
@@ -5111,6 +5112,7 @@ namespace DynamicData
 
         /// <summary>
         /// Converts the observable to an observable changeset
+        /// Change set observes observable change events
         /// </summary>
         /// <typeparam name="TObject">The type of the object.</typeparam>
         /// <typeparam name="TKey">The type of the key.</typeparam>

--- a/src/DynamicData/Cache/ObservableCacheEx.cs
+++ b/src/DynamicData/Cache/ObservableCacheEx.cs
@@ -5076,8 +5076,8 @@ namespace DynamicData
         #region Populate changetset from observables
 
         /// <summary>
-        /// Converts the observable to an observable changeset
-        /// Change set observes observable change events
+        /// Converts the observable to an observable changeset.
+        /// Change set observes observable change events.
         /// </summary>
         /// <typeparam name="TObject">The type of the object.</typeparam>
         /// <typeparam name="TKey">The type of the key.</typeparam>
@@ -5111,8 +5111,8 @@ namespace DynamicData
         }
 
         /// <summary>
-        /// Converts the observable to an observable changeset
-        /// Change set observes observable change events
+        /// Converts the observable to an observable changeset.
+        /// Change set observes observable change events.
         /// </summary>
         /// <typeparam name="TObject">The type of the object.</typeparam>
         /// <typeparam name="TKey">The type of the key.</typeparam>

--- a/src/DynamicData/EnumerableEx.cs
+++ b/src/DynamicData/EnumerableEx.cs
@@ -20,8 +20,8 @@ namespace DynamicData
         #region Populate changeset from standard enumerable
 
         /// <summary>
-        /// Converts the enumerable to an observable changeset
-        /// Generates a snapshot in time based of enumerable
+        /// Converts the enumerable to an observable changeset.
+        /// Generates a snapshot in time based of enumerable.
         /// </summary>
         /// <typeparam name="TObject">The type of the object.</typeparam>
         /// <typeparam name="TKey">The type of the key.</typeparam>
@@ -65,8 +65,8 @@ namespace DynamicData
         #region Populate change set from standard enumerable
 
         /// <summary>
-        /// Converts the enumerable to an observable changeset
-        /// Generates a snapshot in time based of enumerable
+        /// Converts the enumerable to an observable changeset.
+        /// Generates a snapshot in time based of enumerable.
         /// </summary>
         /// <typeparam name="TObject">The type of the object.</typeparam>
         /// <param name="source">The source.</param>

--- a/src/DynamicData/EnumerableEx.cs
+++ b/src/DynamicData/EnumerableEx.cs
@@ -21,6 +21,7 @@ namespace DynamicData
 
         /// <summary>
         /// Converts the enumerable to an observable changeset
+        /// Generates a snapshot in time based of enumerable
         /// </summary>
         /// <typeparam name="TObject">The type of the object.</typeparam>
         /// <typeparam name="TKey">The type of the key.</typeparam>
@@ -65,6 +66,7 @@ namespace DynamicData
 
         /// <summary>
         /// Converts the enumerable to an observable changeset
+        /// Generates a snapshot in time based of enumerable
         /// </summary>
         /// <typeparam name="TObject">The type of the object.</typeparam>
         /// <param name="source">The source.</param>

--- a/src/DynamicData/List/ObservableListEx.cs
+++ b/src/DynamicData/List/ObservableListEx.cs
@@ -33,6 +33,7 @@ namespace DynamicData
 
         /// <summary>
         /// Converts the observable to an observable changeset.
+        /// Change set observes observable change events
         /// </summary>
         /// <typeparam name="T">The type of the object.</typeparam>
         /// <param name="source">The source.</param>
@@ -54,6 +55,7 @@ namespace DynamicData
 
         /// <summary>
         /// Converts the observable to an observable changeset, allowing time expiry to be specified
+        /// Change set observes observable change events
         /// </summary>
         /// <typeparam name="T">The type of the object.</typeparam>
         /// <param name="source">The source.</param>
@@ -82,6 +84,7 @@ namespace DynamicData
 
         /// <summary>
         /// Converts the observable to an observable changeset, with a specified limit of how large the list can be.
+        /// Change set observes observable change events
         /// </summary>
         /// <typeparam name="T">The type of the object.</typeparam>
         /// <param name="source">The source.</param>
@@ -105,6 +108,7 @@ namespace DynamicData
 
         /// <summary>
         /// Converts the observable to an observable changeset, allowing size and time limit to be specified
+        /// Change set observes observable change events
         /// </summary>
         /// <typeparam name="T">The type of the object.</typeparam>
         /// <param name="source">The source.</param>
@@ -130,6 +134,7 @@ namespace DynamicData
 
         /// <summary>
         /// Converts the observable to an observable changeset.
+        /// Change set observes observable change events
         /// </summary>
         /// <typeparam name="T">The type of the object.</typeparam>
         /// <param name="source">The source.</param>
@@ -146,6 +151,7 @@ namespace DynamicData
 
         /// <summary>
         /// Converts the observable to an observable changeset, allowing size and time limit to be specified
+        /// Change set observes observable change events
         /// </summary>
         /// <typeparam name="T">The type of the object.</typeparam>
         /// <param name="source">The source.</param>
@@ -164,6 +170,7 @@ namespace DynamicData
 
         /// <summary>
         /// Converts the observable to an observable changeset, allowing size to be specified
+        /// Change set observes observable change events
         /// </summary>
         /// <typeparam name="T">The type of the object.</typeparam>
         /// <param name="source">The source.</param>
@@ -182,6 +189,7 @@ namespace DynamicData
 
         /// <summary>
         /// Converts the observable to an observable changeset, allowing size and time limit to be specified
+        /// Change set observes observable change events
         /// </summary>
         /// <typeparam name="T">The type of the object.</typeparam>
         /// <param name="source">The source.</param>

--- a/src/DynamicData/List/ObservableListEx.cs
+++ b/src/DynamicData/List/ObservableListEx.cs
@@ -33,7 +33,7 @@ namespace DynamicData
 
         /// <summary>
         /// Converts the observable to an observable changeset.
-        /// Change set observes observable change events
+        /// Change set observes observable change events.
         /// </summary>
         /// <typeparam name="T">The type of the object.</typeparam>
         /// <param name="source">The source.</param>
@@ -54,8 +54,8 @@ namespace DynamicData
         }
 
         /// <summary>
-        /// Converts the observable to an observable changeset, allowing time expiry to be specified
-        /// Change set observes observable change events
+        /// Converts the observable to an observable changeset, allowing time expiry to be specified.
+        /// Change set observes observable change events.
         /// </summary>
         /// <typeparam name="T">The type of the object.</typeparam>
         /// <param name="source">The source.</param>
@@ -84,7 +84,7 @@ namespace DynamicData
 
         /// <summary>
         /// Converts the observable to an observable changeset, with a specified limit of how large the list can be.
-        /// Change set observes observable change events
+        /// Change set observes observable change events.
         /// </summary>
         /// <typeparam name="T">The type of the object.</typeparam>
         /// <param name="source">The source.</param>
@@ -107,8 +107,8 @@ namespace DynamicData
         }
 
         /// <summary>
-        /// Converts the observable to an observable changeset, allowing size and time limit to be specified
-        /// Change set observes observable change events
+        /// Converts the observable to an observable changeset, allowing size and time limit to be specified.
+        /// Change set observes observable change events.
         /// </summary>
         /// <typeparam name="T">The type of the object.</typeparam>
         /// <param name="source">The source.</param>
@@ -134,7 +134,7 @@ namespace DynamicData
 
         /// <summary>
         /// Converts the observable to an observable changeset.
-        /// Change set observes observable change events
+        /// Change set observes observable change events.
         /// </summary>
         /// <typeparam name="T">The type of the object.</typeparam>
         /// <param name="source">The source.</param>
@@ -150,8 +150,8 @@ namespace DynamicData
         }
 
         /// <summary>
-        /// Converts the observable to an observable changeset, allowing size and time limit to be specified
-        /// Change set observes observable change events
+        /// Converts the observable to an observable changeset, allowing size and time limit to be specified.
+        /// Change set observes observable change events.
         /// </summary>
         /// <typeparam name="T">The type of the object.</typeparam>
         /// <param name="source">The source.</param>
@@ -169,8 +169,8 @@ namespace DynamicData
         }
 
         /// <summary>
-        /// Converts the observable to an observable changeset, allowing size to be specified
-        /// Change set observes observable change events
+        /// Converts the observable to an observable changeset, allowing size to be specified.
+        /// Change set observes observable change events.
         /// </summary>
         /// <typeparam name="T">The type of the object.</typeparam>
         /// <param name="source">The source.</param>
@@ -188,8 +188,8 @@ namespace DynamicData
         }
 
         /// <summary>
-        /// Converts the observable to an observable changeset, allowing size and time limit to be specified
-        /// Change set observes observable change events
+        /// Converts the observable to an observable changeset, allowing size and time limit to be specified.
+        /// Change set observes observable change events.
         /// </summary>
         /// <typeparam name="T">The type of the object.</typeparam>
         /// <param name="source">The source.</param>


### PR DESCRIPTION
Added description of the special difference between the ToObservableChangeSet and AsObservableChangeSet methods

<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
comments update


**What is the current behavior?**
Two closed in name methods works different. One track item changes and another not.

**What is the new behavior?**
The method description now shows changetracking behavior

**What might this PR break?**
nothing


**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

