### PR TITLE
[impl] remove items not in enumerable anymore

### DIFF
--- a/src/DynamicData/Cache/Internal/ToObservableChangeSet.cs
+++ b/src/DynamicData/Cache/Internal/ToObservableChangeSet.cs
@@ -58,13 +58,16 @@ namespace DynamicData.Cache.Internal
                         if (latest is IList<TObject> list)
                         {
                             //zero allocation enumerator
-                            foreach (var item in EnumerableIList.Create(list))
+                            var elist = EnumerableIList.Create(list);
+                            state.Remove(state.Keys.Except(elist.Select(_keySelector)).ToList());
+                            foreach (var item in elist)
                             {
                                 state.AddOrUpdate(item, _keySelector(item));
                             }
                         }
                         else
                         {
+                            state.Remove(state.Keys.Except(latest.Select(_keySelector)).ToList());
                             foreach (var item in latest)
                             {
                                 state.AddOrUpdate(item, _keySelector(item));


### PR DESCRIPTION
**What kind of change does this PR introduce?**
It changes the behavior of the `toObservableChangeSet()` method when passing an `IEnumerable`.

**What is the current behavior?**
Items that have been in the `IEnumerable` once, will stay in the cache forever (or until expiration).

**What is the new behavior?**
`IEnumerable` entries are compared to the cache. If there are keys in the cache not in the `IEnumerable` anymore, they get removed.

**What might this PR break?**
This changes the behavior of this use case for the `toObservableChangeSet` in general. Not sure if it's a good idea to do it like this.

**Please check if the PR fulfills these requirements**
- [X ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:
To be discussed also in https://github.com/reactiveui/DynamicData/issues/326
