### PR TITLE
Explain the difference between GroupOn and GroupWithImmutableState on ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,8 @@ The `GroupOn` operator pre-caches the specified groups according to the group se
 ```cs
 var myOperation = personChangeSet.GroupOn(person => person.Status)
 ```
+The value of the inner group is represented by an observable list for each matched group. When values matching the inner grouping are modified, it is the inner group which produces the changes.
+You can also use `GroupWithImmutableState` which will produce a grouping who's inner items are a fixed size array.
 
 #### Transformation
 The `Transform` operator allows you to map objects from the observable change set to another object


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
docs update



**What is the current behavior?**
`GroupWithImmutableState` is not mentionned in ReadMe whereas `GroupOn` is.



**What is the new behavior?**
The difference between `GroupWithImmutableState` and `GroupOn` is explained in ReadMe.



**What might this PR break?**
Nothing.



**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:

The distinction between `GroupOn` and `GroupWithImmutableState` was essential to me and I found it on a github issue.

I thought it may as well be in the README.

