### PR TITLE
Bump fluent assertions to 5.10.3. 

### DIFF
--- a/src/DynamicData.Tests/Binding/BindingLIstBindListFixture.cs
+++ b/src/DynamicData.Tests/Binding/BindingLIstBindListFixture.cs
@@ -69,7 +69,7 @@ namespace DynamicData.Tests.Binding
             _source.AddRange(people);
 
             _collection.Count.Should().Be(100, "Should be 100 items in the collection");
-            _collection.ShouldAllBeEquivalentTo(_collection, "Collections should be equivalent");
+            _collection.Should().BeEquivalentTo(_collection, "Collections should be equivalent");
         }
 
         [Fact]

--- a/src/DynamicData.Tests/Binding/BindingListBindCacheFixture.cs
+++ b/src/DynamicData.Tests/Binding/BindingListBindCacheFixture.cs
@@ -68,7 +68,7 @@ namespace DynamicData.Tests.Binding
             _source.AddOrUpdate(people);
 
             _collection.Count.Should().Be(100, "Should be 100 items in the collection");
-            _collection.ShouldAllBeEquivalentTo(_collection, "Collections should be equivalent");
+            _collection.Should().BeEquivalentTo(_collection, "Collections should be equivalent");
         }
 
         [Fact]

--- a/src/DynamicData.Tests/Binding/BindingListBindCacheSortedFixture.cs
+++ b/src/DynamicData.Tests/Binding/BindingListBindCacheSortedFixture.cs
@@ -75,7 +75,7 @@ namespace DynamicData.Tests.Binding
             _source.AddOrUpdate(people);
 
             _collection.Count.Should().Be(100, "Should be 100 items in the collection");
-            _collection.ShouldAllBeEquivalentTo(_collection, "Collections should be equivalent");
+            _collection.Should().BeEquivalentTo(_collection, "Collections should be equivalent");
         }
 
         [Fact]
@@ -92,7 +92,7 @@ namespace DynamicData.Tests.Binding
         {
             _source.AddOrUpdate(_generator.Take(100));
             var sorted = _source.Items.OrderBy(p => p, _comparer).ToList();
-            sorted.ShouldAllBeEquivalentTo(_collection.ToList());
+            sorted.Should().BeEquivalentTo(_collection.ToList());
         }
 
         [Fact]

--- a/src/DynamicData.Tests/Binding/BindingListToChangeSetFixture.cs
+++ b/src/DynamicData.Tests/Binding/BindingListToChangeSetFixture.cs
@@ -42,7 +42,7 @@ namespace DynamicData.Tests.Binding
 
             _results.Data.Count.Should().Be(9);
             _results.Data.Items.Contains(3).Should().BeFalse();
-            _results.Data.Items.ShouldAllBeEquivalentTo(_collection);
+            _results.Data.Items.Should().BeEquivalentTo(_collection);
         }
 
         [Fact]
@@ -60,7 +60,7 @@ namespace DynamicData.Tests.Binding
             _collection.AddRange(Enumerable.Range(1, 10));
             _collection[8] = 20;
 
-            _results.Data.Items.ShouldBeEquivalentTo(new[] { 1, 2, 3, 4, 5, 6, 7, 8, 20, 10 });
+            _results.Data.Items.Should().BeEquivalentTo(new[] { 1, 2, 3, 4, 5, 6, 7, 8, 20, 10 });
         }
 
         [Fact]
@@ -69,7 +69,7 @@ namespace DynamicData.Tests.Binding
             _collection.AddRange(Enumerable.Range(1, 10));
 
             _collection.Reset();
-            _results.Data.Items.ShouldAllBeEquivalentTo(_collection);
+            _results.Data.Items.Should().BeEquivalentTo(_collection);
 
             var resetNotification = _results.Messages.Last();
             resetNotification.Removes.Should().Be(10);

--- a/src/DynamicData.Tests/Binding/ObservableCollectionBindCacheFixture.cs
+++ b/src/DynamicData.Tests/Binding/ObservableCollectionBindCacheFixture.cs
@@ -66,7 +66,7 @@ namespace DynamicData.Tests.Binding
             _source.AddOrUpdate(people);
 
             _collection.Count.Should().Be(100, "Should be 100 items in the collection");
-            _collection.ShouldAllBeEquivalentTo(_collection, "Collections should be equivalent");
+            _collection.Should().BeEquivalentTo(_collection, "Collections should be equivalent");
         }
 
         [Fact]

--- a/src/DynamicData.Tests/Binding/ObservableCollectionBindCacheSortedFixture.cs
+++ b/src/DynamicData.Tests/Binding/ObservableCollectionBindCacheSortedFixture.cs
@@ -73,7 +73,7 @@ namespace DynamicData.Tests.Binding
             _source.AddOrUpdate(people);
 
             _collection.Count.Should().Be(100, "Should be 100 items in the collection");
-            _collection.ShouldAllBeEquivalentTo(_collection, "Collections should be equivalent");
+            _collection.Should().BeEquivalentTo(_collection, "Collections should be equivalent");
         }
 
         [Fact]
@@ -90,7 +90,7 @@ namespace DynamicData.Tests.Binding
         {
             _source.AddOrUpdate(_generator.Take(100));
             var sorted = _source.Items.OrderBy(p => p, _comparer).ToList();
-            sorted.ShouldAllBeEquivalentTo(_collection.ToList());
+            sorted.Should().BeEquivalentTo(_collection.ToList());
         }
 
         [Fact]

--- a/src/DynamicData.Tests/Binding/ObservableCollectionBindListFixture.cs
+++ b/src/DynamicData.Tests/Binding/ObservableCollectionBindListFixture.cs
@@ -67,7 +67,7 @@ namespace DynamicData.Tests.Binding
             _source.AddRange(people);
 
             _collection.Count.Should().Be(100, "Should be 100 items in the collection");
-            _collection.ShouldAllBeEquivalentTo(_collection, "Collections should be equivalent");
+            _collection.Should().BeEquivalentTo(_collection, "Collections should be equivalent");
         }
 
         [Fact]

--- a/src/DynamicData.Tests/Binding/ObservableCollectionExtendedToChangeSetFixture.cs
+++ b/src/DynamicData.Tests/Binding/ObservableCollectionExtendedToChangeSetFixture.cs
@@ -31,12 +31,12 @@ namespace DynamicData.Tests.Binding
         {
             _collection.AddRange(Enumerable.Range(1, 10));
 
-            _results.Data.Items.ShouldAllBeEquivalentTo(_target);
+            _results.Data.Items.Should().BeEquivalentTo(_target);
             _collection.Move(5, 8);
-            _results.Data.Items.ShouldAllBeEquivalentTo(_target);
+            _results.Data.Items.Should().BeEquivalentTo(_target);
 
             _collection.Move(7, 1);
-            _results.Data.Items.ShouldAllBeEquivalentTo(_target);
+            _results.Data.Items.Should().BeEquivalentTo(_target);
         }
 
         [Fact]
@@ -58,7 +58,7 @@ namespace DynamicData.Tests.Binding
 
             _results.Data.Count.Should().Be(9);
             _results.Data.Items.Contains(3).Should().BeFalse();
-            _results.Data.Items.ShouldAllBeEquivalentTo(_target);
+            _results.Data.Items.Should().BeEquivalentTo(_target);
         }
 
         [Fact]
@@ -76,7 +76,7 @@ namespace DynamicData.Tests.Binding
             _collection.AddRange(Enumerable.Range(1, 10));
             _collection[8] = 20;
 
-            _results.Data.Items.ShouldBeEquivalentTo(new[] { 1, 2, 3, 4, 5, 6, 7, 8, 20, 10 });
+            _results.Data.Items.Should().BeEquivalentTo(new[] { 1, 2, 3, 4, 5, 6, 7, 8, 20, 10 });
 
         }
 
@@ -86,7 +86,7 @@ namespace DynamicData.Tests.Binding
         //    _collection.AddRange(Enumerable.Range(1, 10));
 
         //    _collection.Reset();
-        //    _results.Data.Items.ShouldAllBeEquivalentTo(_target);
+        //    _results.Data.Items.Should().BeEquivalentTo(_target);
 
         //    var resetNotification = _results.Messages.Last();
         //    resetNotification.Removes.Should().Be(10);

--- a/src/DynamicData.Tests/Binding/ObservableCollectionToChangeSetFixture.cs
+++ b/src/DynamicData.Tests/Binding/ObservableCollectionToChangeSetFixture.cs
@@ -30,12 +30,12 @@ namespace DynamicData.Tests.Binding
         {
             _collection.AddRange(Enumerable.Range(1, 10));
 
-            _results.Data.Items.ShouldAllBeEquivalentTo(_collection);
+            _results.Data.Items.Should().BeEquivalentTo(_collection);
             _collection.Move(5, 8);
-            _results.Data.Items.ShouldAllBeEquivalentTo(_collection);
+            _results.Data.Items.Should().BeEquivalentTo(_collection);
 
             _collection.Move(7, 1);
-            _results.Data.Items.ShouldAllBeEquivalentTo(_collection);
+            _results.Data.Items.Should().BeEquivalentTo(_collection);
         }
 
         [Fact]
@@ -57,7 +57,7 @@ namespace DynamicData.Tests.Binding
 
             _results.Data.Count.Should().Be(9);
             _results.Data.Items.Contains(3).Should().BeFalse();
-            _results.Data.Items.ShouldAllBeEquivalentTo(_collection);
+            _results.Data.Items.Should().BeEquivalentTo(_collection);
         }
 
         [Fact]
@@ -75,7 +75,7 @@ namespace DynamicData.Tests.Binding
             _collection.AddRange(Enumerable.Range(1, 10));
             _collection[8] = 20;
 
-            _results.Data.Items.ShouldBeEquivalentTo(new []{1,2,3,4,5,6,7,8,20,10});
+            _results.Data.Items.Should().BeEquivalentTo(new []{1,2,3,4,5,6,7,8,20,10});
 
         }
 
@@ -85,7 +85,7 @@ namespace DynamicData.Tests.Binding
             _collection.AddRange(Enumerable.Range(1, 10));
 
             _collection.Reset();
-            _results.Data.Items.ShouldAllBeEquivalentTo(_collection);
+            _results.Data.Items.Should().BeEquivalentTo(_collection);
 
             var resetNotification = _results.Messages.Last();
             resetNotification.Removes.Should().Be(10);

--- a/src/DynamicData.Tests/Binding/ReadOnlyObservableCollectionToChangeSetFixture.cs
+++ b/src/DynamicData.Tests/Binding/ReadOnlyObservableCollectionToChangeSetFixture.cs
@@ -32,12 +32,12 @@ namespace DynamicData.Tests.Binding
         {
             _collection.AddRange(Enumerable.Range(1, 10));
 
-            _results.Data.Items.ShouldAllBeEquivalentTo(_target);
+            _results.Data.Items.Should().BeEquivalentTo(_target);
             _collection.Move(5, 8);
-            _results.Data.Items.ShouldAllBeEquivalentTo(_target);
+            _results.Data.Items.Should().BeEquivalentTo(_target);
 
             _collection.Move(7, 1);
-            _results.Data.Items.ShouldAllBeEquivalentTo(_target);
+            _results.Data.Items.Should().BeEquivalentTo(_target);
         }
 
         [Fact]
@@ -59,7 +59,7 @@ namespace DynamicData.Tests.Binding
 
             _results.Data.Count.Should().Be(9);
             _results.Data.Items.Contains(3).Should().BeFalse();
-            _results.Data.Items.ShouldAllBeEquivalentTo(_target);
+            _results.Data.Items.Should().BeEquivalentTo(_target);
         }
 
         [Fact]
@@ -77,7 +77,7 @@ namespace DynamicData.Tests.Binding
             _collection.AddRange(Enumerable.Range(1, 10));
             _collection[8] = 20;
 
-            _results.Data.Items.ShouldBeEquivalentTo(new[] { 1, 2, 3, 4, 5, 6, 7, 8, 20, 10 });
+            _results.Data.Items.Should().BeEquivalentTo(new[] { 1, 2, 3, 4, 5, 6, 7, 8, 20, 10 });
         }
 
         [Fact]
@@ -86,7 +86,7 @@ namespace DynamicData.Tests.Binding
             _collection.AddRange(Enumerable.Range(1, 10));
 
             _collection.Reset();
-            _results.Data.Items.ShouldAllBeEquivalentTo(_target);
+            _results.Data.Items.Should().BeEquivalentTo(_target);
 
             var resetNotification = _results.Messages.Last();
             resetNotification.Removes.Should().Be(10);

--- a/src/DynamicData.Tests/Cache/DistinctFixture.cs
+++ b/src/DynamicData.Tests/Cache/DistinctFixture.cs
@@ -49,7 +49,7 @@ namespace DynamicData.Tests.Cache
             _results.Messages.Count.Should().Be(1, "Should be 1 updates");
             _results.Data.Count.Should().Be(3, "Should be 3 items in the cache");
 
-            _results.Data.Items.ShouldAllBeEquivalentTo(new[] {20, 21, 22});
+            _results.Data.Items.Should().BeEquivalentTo(new[] {20, 21, 22});
             _results.Data.Items.First().Should().Be(20, "Should 20");
         }
 
@@ -94,12 +94,12 @@ namespace DynamicData.Tests.Cache
                 updater.AddOrUpdate(new Person("Person4", 14));
             });
 
-            _results.Data.Items.ShouldAllBeEquivalentTo(new[] {1, 12, 13, 14});
+            _results.Data.Items.Should().BeEquivalentTo(new[] {1, 12, 13, 14});
 
             //This previously threw
             _source.Remove(new Person("Person3", 13));
 
-            _results.Data.Items.ShouldAllBeEquivalentTo(new[] {1, 12, 14});
+            _results.Data.Items.Should().BeEquivalentTo(new[] {1, 12, 14});
         }
 
         [Fact]
@@ -118,7 +118,7 @@ namespace DynamicData.Tests.Cache
             source1.Refresh(person); // would previously throw KeyNotFoundException here
 
             results.Messages.Should().HaveCount(1);
-            results.Data.Items.ShouldAllBeEquivalentTo(new[] {12});
+            results.Data.Items.Should().BeEquivalentTo(new[] {12});
 
             source1.Remove(person);
 

--- a/src/DynamicData.Tests/Cache/DynamicAndFixture.cs
+++ b/src/DynamicData.Tests/Cache/DynamicAndFixture.cs
@@ -105,7 +105,7 @@ namespace DynamicData.Tests.Cache
             _source.Add(_source2.Connect());
 
             _results.Data.Count.Should().Be(10);
-            _results.Data.Items.ShouldAllBeEquivalentTo(items.Skip(10).Take(10));
+            _results.Data.Items.Should().BeEquivalentTo(items.Skip(10).Take(10));
 
             _source.Add(_source3.Connect());
             _results.Data.Count.Should().Be(0);

--- a/src/DynamicData.Tests/Cache/DynamicExceptFixture.cs
+++ b/src/DynamicData.Tests/Cache/DynamicExceptFixture.cs
@@ -91,15 +91,15 @@ namespace DynamicData.Tests.Cache
             _source.Add(_source3.Connect());
 
             _results.Data.Count.Should().Be(80);
-            _results.Data.Items.ShouldAllBeEquivalentTo(items.Skip(10).Take(80));
+            _results.Data.Items.Should().BeEquivalentTo(items.Skip(10).Take(80));
 
             _source.RemoveAt(2);
             _results.Data.Count.Should().Be(90);
-            _results.Data.Items.ShouldAllBeEquivalentTo(items.Skip(10));
+            _results.Data.Items.Should().BeEquivalentTo(items.Skip(10));
 
             _source.RemoveAt(0);
             _results.Data.Count.Should().Be(10);
-            _results.Data.Items.ShouldAllBeEquivalentTo(items.Take(10));
+            _results.Data.Items.Should().BeEquivalentTo(items.Take(10));
         }
 
         [Fact]

--- a/src/DynamicData.Tests/Cache/DynamicOrFixture.cs
+++ b/src/DynamicData.Tests/Cache/DynamicOrFixture.cs
@@ -108,14 +108,14 @@ namespace DynamicData.Tests.Cache
             _source.Add(_source3.Connect());
 
             _results.Data.Count.Should().Be(100);
-            _results.Data.Items.ShouldAllBeEquivalentTo(items);
+            _results.Data.Items.Should().BeEquivalentTo(items);
 
             _source.RemoveAt(1);
             var result = items.Take(10)
                 .Union(items.Skip(20));
 
             _results.Data.Count.Should().Be(90);
-            _results.Data.Items.ShouldAllBeEquivalentTo(result);
+            _results.Data.Items.Should().BeEquivalentTo(result);
         }
 
         [Fact]

--- a/src/DynamicData.Tests/Cache/DynamicXorFixture.cs
+++ b/src/DynamicData.Tests/Cache/DynamicXorFixture.cs
@@ -106,13 +106,13 @@ namespace DynamicData.Tests.Cache
             _source.Add(_source3.Connect());
 
             _results.Data.Count.Should().Be(100);
-            _results.Data.Items.ShouldAllBeEquivalentTo(items);
+            _results.Data.Items.Should().BeEquivalentTo(items);
 
             _source.RemoveAt(1);
 
             var result = items.Take(10).Union(items.Skip(20));
             _results.Data.Count.Should().Be(90);
-            _results.Data.Items.ShouldAllBeEquivalentTo(result);
+            _results.Data.Items.Should().BeEquivalentTo(result);
         }
 
         [Fact]

--- a/src/DynamicData.Tests/Cache/EditDiffFixture.cs
+++ b/src/DynamicData.Tests/Cache/EditDiffFixture.cs
@@ -34,7 +34,7 @@ namespace DynamicData.Tests.Cache
             _cache.EditDiff(newPeople, (current, previous) => Person.AgeComparer.Equals(current, previous));
 
             _cache.Count.Should().Be(15);
-            _cache.Items.ShouldAllBeEquivalentTo(newPeople);
+            _cache.Items.Should().BeEquivalentTo(newPeople);
             var lastChange = _result.Messages.Last();
             lastChange.Adds.Should().Be(5);
         }
@@ -47,7 +47,7 @@ namespace DynamicData.Tests.Cache
             _cache.EditDiff(newPeople, (current, previous) => Person.AgeComparer.Equals(current, previous));
 
             _cache.Count.Should().Be(10);
-            _cache.Items.ShouldAllBeEquivalentTo(newPeople);
+            _cache.Items.Should().BeEquivalentTo(newPeople);
             _result.Messages.Count.Should().Be(1);
         }
 
@@ -64,7 +64,7 @@ namespace DynamicData.Tests.Cache
             lastChange.Updates.Should().Be(3);
             lastChange.Removes.Should().Be(7);
 
-            _cache.Items.ShouldAllBeEquivalentTo(newList);
+            _cache.Items.Should().BeEquivalentTo(newList);
         }
 
         [Fact]
@@ -80,7 +80,7 @@ namespace DynamicData.Tests.Cache
             lastChange.Updates.Should().Be(0);
             lastChange.Removes.Should().Be(3);
 
-            _cache.Items.ShouldAllBeEquivalentTo(newList);
+            _cache.Items.Should().BeEquivalentTo(newList);
         }
 
         [Fact]
@@ -97,7 +97,7 @@ namespace DynamicData.Tests.Cache
             lastChange.Updates.Should().Be(5);
             lastChange.Removes.Should().Be(5);
 
-            _cache.Items.ShouldAllBeEquivalentTo(newList);
+            _cache.Items.Should().BeEquivalentTo(newList);
         }
 
         [Fact]
@@ -108,7 +108,7 @@ namespace DynamicData.Tests.Cache
             _cache.EditDiff(newPeople, Person.AgeComparer);
 
             _cache.Count.Should().Be(15);
-            _cache.Items.ShouldAllBeEquivalentTo(newPeople);
+            _cache.Items.Should().BeEquivalentTo(newPeople);
             var lastChange = _result.Messages.Last();
             lastChange.Adds.Should().Be(5);
         }
@@ -121,7 +121,7 @@ namespace DynamicData.Tests.Cache
             _cache.EditDiff(newPeople, Person.AgeComparer);
 
             _cache.Count.Should().Be(10);
-            _cache.Items.ShouldAllBeEquivalentTo(newPeople);
+            _cache.Items.Should().BeEquivalentTo(newPeople);
             var lastChange = _result.Messages.Last();
             _result.Messages.Count.Should().Be(1);
         }
@@ -139,7 +139,7 @@ namespace DynamicData.Tests.Cache
             lastChange.Updates.Should().Be(3);
             lastChange.Removes.Should().Be(7);
 
-            _cache.Items.ShouldAllBeEquivalentTo(newList);
+            _cache.Items.Should().BeEquivalentTo(newList);
         }
 
         [Fact]
@@ -155,7 +155,7 @@ namespace DynamicData.Tests.Cache
             lastChange.Updates.Should().Be(0);
             lastChange.Removes.Should().Be(3);
 
-            _cache.Items.ShouldAllBeEquivalentTo(newList);
+            _cache.Items.Should().BeEquivalentTo(newList);
         }
 
         [Fact]
@@ -172,7 +172,7 @@ namespace DynamicData.Tests.Cache
             lastChange.Updates.Should().Be(5);
             lastChange.Removes.Should().Be(5);
 
-            _cache.Items.ShouldAllBeEquivalentTo(newList);
+            _cache.Items.Should().BeEquivalentTo(newList);
         }
     }
 }

--- a/src/DynamicData.Tests/Cache/EnumerableObservableToObservableChangeSetFixture.cs
+++ b/src/DynamicData.Tests/Cache/EnumerableObservableToObservableChangeSetFixture.cs
@@ -29,7 +29,7 @@ namespace DynamicData.Tests.Cache
 
             results.Messages.Count.Should().Be(1, "Should be 1 updates");
             results.Data.Count.Should().Be(3, "Should be 1 item in the cache");
-            results.Data.Items.ShouldAllBeEquivalentTo(results.Data.Items, "Lists should be equivalent");
+            results.Data.Items.Should().BeEquivalentTo(results.Data.Items, "Lists should be equivalent");
         }
 
         [Fact]
@@ -64,7 +64,7 @@ namespace DynamicData.Tests.Cache
             results.Data.Count.Should().Be(2, "Should be 3 items in the cache");
 
             results.Messages.Count.Should().Be(2, "Should be 2 updates");
-            results.Data.Items.ShouldAllBeEquivalentTo(results.Data.Items, "Lists should be equivalent");
+            results.Data.Items.Should().BeEquivalentTo(results.Data.Items, "Lists should be equivalent");
         }
 
         [Fact]
@@ -86,7 +86,7 @@ namespace DynamicData.Tests.Cache
 
             var expected = people.Skip(100).ToArray().OrderBy(p => p.Name).ToArray();
             var actual = results.Data.Items.OrderBy(p => p.Name).ToArray();
-            actual.ShouldAllBeEquivalentTo(expected, "Only second hundred should be in the cache");
+            actual.Should().BeEquivalentTo(expected, "Only second hundred should be in the cache");
         }
 
         [Fact]

--- a/src/DynamicData.Tests/Cache/FilterControllerFixture.cs
+++ b/src/DynamicData.Tests/Cache/FilterControllerFixture.cs
@@ -188,7 +188,7 @@ namespace DynamicData.Tests.Cache
             _results.Messages[0].Adds.Should().Be(80, "Should return 80 adds");
 
             var filtered = people.Where(p => p.Age > 20).OrderBy(p => p.Age).ToArray();
-            _results.Data.Items.OrderBy(p => p.Age).ShouldAllBeEquivalentTo(filtered, "Incorrect Filter result");
+            _results.Data.Items.OrderBy(p => p.Age).Should().BeEquivalentTo(filtered, "Incorrect Filter result");
         }
 
         [Fact]
@@ -218,7 +218,7 @@ namespace DynamicData.Tests.Cache
             _results.Messages.Count.Should().Be(80, "Should be 80 messages");
             _results.Data.Count.Should().Be(80, "Should be 80 in the cache");
             var filtered = people.Where(p => p.Age > 20).OrderBy(p => p.Age).ToArray();
-            _results.Data.Items.OrderBy(p => p.Age).ShouldAllBeEquivalentTo(filtered, "Incorrect Filter result");
+            _results.Data.Items.OrderBy(p => p.Age).Should().BeEquivalentTo(filtered, "Incorrect Filter result");
         }
 
         [Fact]

--- a/src/DynamicData.Tests/Cache/FilterFixture.cs
+++ b/src/DynamicData.Tests/Cache/FilterFixture.cs
@@ -82,7 +82,8 @@ namespace DynamicData.Tests.Cache
             _results.Messages[0].Adds.Should().Be(80, "Should return 80 adds");
 
             var filtered = people.Where(p => p.Age > 20).OrderBy(p => p.Age).ToArray();
-            _results.Data.Items.OrderBy(p => p.Age).ShouldAllBeEquivalentTo(filtered, "Incorrect Filter result");
+            var expected = _results.Data.Items.OrderBy(p => p.Age).ToArray();
+            expected.Should().BeEquivalentTo(filtered, "Incorrect Filter result");
         }
 
         [Fact]
@@ -112,7 +113,7 @@ namespace DynamicData.Tests.Cache
             _results.Messages.Count.Should().Be(80, "Should be 100 updates");
             _results.Data.Count.Should().Be(80, "Should be 100 in the cache");
             var filtered = people.Where(p => p.Age > 20).OrderBy(p => p.Age).ToArray();
-            _results.Data.Items.OrderBy(p => p.Age).ShouldAllBeEquivalentTo(filtered, "Incorrect Filter result");
+            _results.Data.Items.OrderBy(p => p.Age).Should().BeEquivalentTo(filtered, "Incorrect Filter result");
         }
 
         [Fact]

--- a/src/DynamicData.Tests/Cache/FilterOnPropertyFixture.cs
+++ b/src/DynamicData.Tests/Cache/FilterOnPropertyFixture.cs
@@ -20,7 +20,7 @@ namespace DynamicData.Tests.Cache
                 1.Should().Be(stub.Results.Messages.Count);
                 82.Should().Be(stub.Results.Data.Count);
 
-                stub.Results.Data.Items.ShouldAllBeEquivalentTo(people.Skip(18));
+                stub.Results.Data.Items.Should().BeEquivalentTo(people.Skip(18));
             }
         }
 

--- a/src/DynamicData.Tests/Cache/FilterParallelFixture.cs
+++ b/src/DynamicData.Tests/Cache/FilterParallelFixture.cs
@@ -82,7 +82,7 @@ namespace DynamicData.Tests.Cache
             _results.Messages[0].Adds.Should().Be(80, "Should return 80 adds");
 
             var filtered = people.Where(p => p.Age > 20).OrderBy(p => p.Name).ToArray();
-            _results.Data.Items.OrderBy(p => p.Name).ShouldAllBeEquivalentTo(filtered, "Incorrect Filter result");
+            _results.Data.Items.OrderBy(p => p.Name).Should().BeEquivalentTo(filtered, "Incorrect Filter result");
         }
 
         [Fact]
@@ -112,7 +112,7 @@ namespace DynamicData.Tests.Cache
             _results.Messages.Count.Should().Be(80, "Should be 100 updates");
             _results.Data.Count.Should().Be(80, "Should be 100 in the cache");
             var filtered = people.Where(p => p.Age > 20).OrderBy(p => p.Age).ToArray();
-            _results.Data.Items.OrderBy(p => p.Age).ShouldAllBeEquivalentTo(filtered, "Incorrect Filter result");
+            _results.Data.Items.OrderBy(p => p.Age).Should().BeEquivalentTo(filtered, "Incorrect Filter result");
         }
 
         [Fact]

--- a/src/DynamicData.Tests/Cache/FullJoinManyFixture.cs
+++ b/src/DynamicData.Tests/Cache/FullJoinManyFixture.cs
@@ -159,7 +159,7 @@ namespace DynamicData.Tests.Cache
             {
                 var result = _result.Data.Lookup(parentAndChild.ParentId).ValueOr(() => null);
                 var children = result.Children;
-                children.ShouldAllBeEquivalentTo(parentAndChild.Children);
+                children.Should().BeEquivalentTo(parentAndChild.Children);
             });
         }
 

--- a/src/DynamicData.Tests/Cache/GroupImmutableFixture.cs
+++ b/src/DynamicData.Tests/Cache/GroupImmutableFixture.cs
@@ -123,7 +123,7 @@ namespace DynamicData.Tests.Cache
                 .ForEach(group =>
                 {
                     var cache = _results.Data.Lookup(group.Key).Value;
-                    cache.Items.ShouldAllBeEquivalentTo(group);
+                    cache.Items.Should().BeEquivalentTo(group);
                 });
 
             var changedPeople = Enumerable.Range(1, 100)
@@ -136,7 +136,7 @@ namespace DynamicData.Tests.Cache
                 .ForEach(group =>
                 {
                     var cache = _results.Data.Lookup(group.Key).Value;
-                    cache.Items.ShouldAllBeEquivalentTo(group);
+                    cache.Items.Should().BeEquivalentTo(group);
                 });
 
             _results.Messages.Count.Should().Be(2);
@@ -168,7 +168,7 @@ namespace DynamicData.Tests.Cache
                 .ForEach(group =>
                 {
                     var cache = _results.Data.Lookup(group.Key).Value;
-                    cache.Items.ShouldAllBeEquivalentTo(group);
+                    cache.Items.Should().BeEquivalentTo(group);
 
                 });
 

--- a/src/DynamicData.Tests/Cache/InnerJoinManyFixture.cs
+++ b/src/DynamicData.Tests/Cache/InnerJoinManyFixture.cs
@@ -160,7 +160,7 @@ namespace DynamicData.Tests.Cache
                     .ValueOrThrow(() => new Exception("Missing result for " + grouping.Key));
 
                 var children = result.Children;
-                children.ShouldAllBeEquivalentTo(grouping);
+                children.Should().BeEquivalentTo(grouping);
             });
         }
 

--- a/src/DynamicData.Tests/Cache/LeftJoinManyFixture.cs
+++ b/src/DynamicData.Tests/Cache/LeftJoinManyFixture.cs
@@ -37,7 +37,7 @@ namespace DynamicData.Tests.Cache
             _people.AddOrUpdate(people);
 
             _result.Data.Count.Should().Be(10);
-            _result.Data.Items.Select(pac => pac.Parent).ShouldAllBeEquivalentTo(people);
+            _result.Data.Items.Select(pac => pac.Parent).Should().BeEquivalentTo(people);
 
             _result.Data.Items.ForEach(pac => { pac.Count.Should().Be(0); });
         }
@@ -147,7 +147,7 @@ namespace DynamicData.Tests.Cache
         private void AssertDataIsCorrectlyFormed(Person[] expected, params string[] missingParents)
         {
             _result.Data.Count.Should().Be(expected.Length);
-            _result.Data.Items.Select(pac => pac.Parent).ShouldAllBeEquivalentTo(expected);
+            _result.Data.Items.Select(pac => pac.Parent).Should().BeEquivalentTo(expected);
 
             expected.GroupBy(p => p.ParentName)
                 .ForEach(grouping =>
@@ -161,7 +161,7 @@ namespace DynamicData.Tests.Cache
                         .ValueOrThrow(() => new Exception("Missing result for " + grouping.Key));
 
                     var children = result.Children;
-                    children.ShouldAllBeEquivalentTo(grouping);
+                    children.Should().BeEquivalentTo(grouping);
                 });
         }
 

--- a/src/DynamicData.Tests/Cache/ObservableToObservableChangeSetFixture.cs
+++ b/src/DynamicData.Tests/Cache/ObservableToObservableChangeSetFixture.cs
@@ -78,7 +78,7 @@ namespace DynamicData.Tests.Cache
 
             var expected = items.Skip(100).ToArray().OrderBy(p => p.Name).ToArray();
             var actual = results.Data.Items.OrderBy(p => p.Name).ToArray();
-            expected.ShouldAllBeEquivalentTo(actual, "Only second hundred should be in the cache");
+            expected.Should().BeEquivalentTo(actual, "Only second hundred should be in the cache");
         }
 
         [Fact]

--- a/src/DynamicData.Tests/Cache/PageFixture.cs
+++ b/src/DynamicData.Tests/Cache/PageFixture.cs
@@ -50,7 +50,7 @@ namespace DynamicData.Tests.Cache
 
             var expectedResult = people.OrderBy(p => p, changed).Take(25).Select(p => new KeyValuePair<string, Person>(p.Name, p)).ToList();
             var actualResult = _aggregators.Messages.Last().SortedItems.ToList();
-            actualResult.ShouldAllBeEquivalentTo(expectedResult);
+            actualResult.Should().BeEquivalentTo(expectedResult);
         }
 
         [Fact]
@@ -67,7 +67,7 @@ namespace DynamicData.Tests.Cache
             var expectedResult = people.OrderBy(p => p, _comparer).Take(25).Select(p => new KeyValuePair<string, Person>(p.Name, p)).ToList();
             var actualResult = _aggregators.Messages[0].SortedItems.ToList();
 
-            actualResult.ShouldAllBeEquivalentTo(expectedResult);
+            actualResult.Should().BeEquivalentTo(expectedResult);
         }
 
         [Fact]
@@ -80,7 +80,7 @@ namespace DynamicData.Tests.Cache
             var expectedResult = people.OrderBy(p => p, _comparer).Skip(25).Take(25).Select(p => new KeyValuePair<string, Person>(p.Name, p)).ToList();
             var actualResult = _aggregators.Messages[1].SortedItems.ToList();
 
-            actualResult.ShouldAllBeEquivalentTo(expectedResult);
+            actualResult.Should().BeEquivalentTo(expectedResult);
         }
 
         [Fact]
@@ -95,7 +95,7 @@ namespace DynamicData.Tests.Cache
             var expectedResult = people.OrderBy(p => p, _comparer).Take(50).Select(p => new KeyValuePair<string, Person>(p.Name, p)).ToList();
             var actualResult = _aggregators.Messages[1].SortedItems.ToList();
 
-            actualResult.ShouldAllBeEquivalentTo(expectedResult);
+            actualResult.Should().BeEquivalentTo(expectedResult);
         }
 
         [Fact]
@@ -110,7 +110,7 @@ namespace DynamicData.Tests.Cache
             var expectedResult = people.OrderBy(p => p, _comparer).Skip(75).Take(25).Select(p => new KeyValuePair<string, Person>(p.Name, p)).ToList();
             var actualResult = _aggregators.Messages[1].SortedItems.ToList();
 
-            actualResult.ShouldAllBeEquivalentTo(expectedResult);
+            actualResult.Should().BeEquivalentTo(expectedResult);
         }
 
         [Fact]

--- a/src/DynamicData.Tests/Cache/RightJoinManyFixture.cs
+++ b/src/DynamicData.Tests/Cache/RightJoinManyFixture.cs
@@ -161,7 +161,7 @@ namespace DynamicData.Tests.Cache
                     .ValueOrThrow(() => new Exception("Missing result for " + grouping.Key));
 
                 var children = result.Children;
-                children.ShouldAllBeEquivalentTo(grouping);
+                children.Should().BeEquivalentTo(grouping);
             });
         }
 

--- a/src/DynamicData.Tests/Cache/SortFixture.cs
+++ b/src/DynamicData.Tests/Cache/SortFixture.cs
@@ -186,7 +186,7 @@ namespace DynamicData.Tests.Cache
             var expectedResult = people.OrderBy(p => p, _comparer).Select(p => new KeyValuePair<string, Person>(p.Name, p)).ToList();
             var actualResult = _results.Messages[0].SortedItems.ToList();
 
-            actualResult.ShouldAllBeEquivalentTo(expectedResult);
+            actualResult.Should().BeEquivalentTo(expectedResult);
         }
 
         [Fact]
@@ -225,7 +225,7 @@ namespace DynamicData.Tests.Cache
 
             var list = _results.Messages[1].SortedItems.ToList();
             var sortedResult = list.OrderBy(p => _comparer).ToList();
-            list.ShouldAllBeEquivalentTo(sortedResult);
+            list.Should().BeEquivalentTo(sortedResult);
         }
 
         [Fact]
@@ -246,7 +246,7 @@ namespace DynamicData.Tests.Cache
 
             var list = _results.Messages[1].SortedItems.ToList();
             var sortedResult = list.OrderBy(p => _comparer).ToList();
-            list.ShouldAllBeEquivalentTo(sortedResult);
+            list.Should().BeEquivalentTo(sortedResult);
         }
 
         [Fact]
@@ -267,7 +267,7 @@ namespace DynamicData.Tests.Cache
 
             var list = _results.Messages[1].SortedItems.ToList();
             var sortedResult = list.OrderBy(p => _comparer).ToList();
-            list.ShouldAllBeEquivalentTo(sortedResult);
+            list.Should().BeEquivalentTo(sortedResult);
         }
 
         [Fact]
@@ -289,7 +289,7 @@ namespace DynamicData.Tests.Cache
 
             var list = _results.Messages[1].SortedItems.ToList();
             var sortedResult = list.OrderBy(p => _comparer).ToList();
-            list.ShouldAllBeEquivalentTo(sortedResult);
+            list.Should().BeEquivalentTo(sortedResult);
         }
 
         [Fact]
@@ -310,7 +310,7 @@ namespace DynamicData.Tests.Cache
 
             var list = _results.Messages[1].SortedItems.ToList();
             var sortedResult = list.OrderBy(p => _comparer).ToList();
-            list.ShouldAllBeEquivalentTo(sortedResult);
+            list.Should().BeEquivalentTo(sortedResult);
         }
 
         [Fact]
@@ -331,7 +331,7 @@ namespace DynamicData.Tests.Cache
             ReferenceEquals(update, indexedItem.Value.Value).Should().BeTrue();
             var list = _results.Messages[1].SortedItems.ToList();
             var sortedResult = list.OrderBy(p => _comparer).ToList();
-            list.ShouldAllBeEquivalentTo(sortedResult);
+            list.Should().BeEquivalentTo(sortedResult);
         }
 
         [Fact]
@@ -353,7 +353,7 @@ namespace DynamicData.Tests.Cache
             ReferenceEquals(update, indexedItem.Value.Value).Should().BeTrue();
             var list = _results.Messages[1].SortedItems.ToList();
             var sortedResult = list.OrderBy(p => _comparer).ToList();
-            list.ShouldAllBeEquivalentTo(sortedResult);
+            list.Should().BeEquivalentTo(sortedResult);
         }
 
         [Fact]
@@ -376,7 +376,7 @@ namespace DynamicData.Tests.Cache
             ReferenceEquals(update, indexedItem.Value.Value).Should().BeTrue();
             var list = _results.Messages[1].SortedItems.ToList();
             var sortedResult = list.OrderBy(p => _comparer).ToList();
-            list.ShouldAllBeEquivalentTo(sortedResult);
+            list.Should().BeEquivalentTo(sortedResult);
         }
 
         [Fact]
@@ -401,7 +401,7 @@ namespace DynamicData.Tests.Cache
             adaptor.Adapt(_results.Messages.Last(), list);
 
             var shouldbe = _results.Messages.Last().SortedItems.Select(p => p.Value).ToList();
-            list.ShouldAllBeEquivalentTo(shouldbe);
+            list.Should().BeEquivalentTo(shouldbe);
         }
 
         [Fact]
@@ -429,7 +429,7 @@ namespace DynamicData.Tests.Cache
             adaptor.Adapt(_results.Messages.Last(), list);
 
             var shouldbe = _results.Messages.Last().SortedItems.Select(p => p.Value).ToList();
-            list.ShouldAllBeEquivalentTo(shouldbe);
+            list.Should().BeEquivalentTo(shouldbe);
         }
 
         [Fact]
@@ -453,7 +453,7 @@ namespace DynamicData.Tests.Cache
             adaptor.Adapt(_results.Messages.Last(), list);
 
             var shouldbe = _results.Messages.Last().SortedItems.Select(p => p.Value).ToList();
-            list.ShouldAllBeEquivalentTo(shouldbe);
+            list.Should().BeEquivalentTo(shouldbe);
         }
 
         [Fact]
@@ -478,7 +478,7 @@ namespace DynamicData.Tests.Cache
             adaptor.Adapt(_results.Messages.Last(), list);
 
             var shouldbe = _results.Messages.Last().SortedItems.Select(p => p.Value).ToList();
-            list.ShouldAllBeEquivalentTo(shouldbe);
+            list.Should().BeEquivalentTo(shouldbe);
         }
 
         [Fact]
@@ -504,7 +504,7 @@ namespace DynamicData.Tests.Cache
             adaptor.Adapt(_results.Messages.Last(), list);
 
             var shouldbe = _results.Messages.Last().SortedItems.Select(p => p.Value).ToList();
-            list.ShouldAllBeEquivalentTo(shouldbe);
+            list.Should().BeEquivalentTo(shouldbe);
         }
 
         [Fact]
@@ -527,7 +527,7 @@ namespace DynamicData.Tests.Cache
             adaptor.Adapt(_results.Messages.Last(), list);
 
             var shouldbe = _results.Messages.Last().SortedItems.Select(p => p.Value).ToList();
-            list.ShouldAllBeEquivalentTo(shouldbe);
+            list.Should().BeEquivalentTo(shouldbe);
         }
 
         [Fact]
@@ -544,7 +544,7 @@ namespace DynamicData.Tests.Cache
             adaptor.Adapt(_results.Messages.Last(), list);
 
             var shouldbe = _results.Messages.Last().SortedItems.Select(p => p.Value).ToList();
-            list.ShouldAllBeEquivalentTo(shouldbe);
+            list.Should().BeEquivalentTo(shouldbe);
         }
     }
 
@@ -719,7 +719,7 @@ namespace DynamicData.Tests.Cache
             var expectedResult = people.OrderBy(p => p, _comparer).Select(p => new KeyValuePair<string, Person>(p.Name, p)).ToList();
             var actualResult = _results.Messages[0].SortedItems.ToList();
 
-            actualResult.ShouldAllBeEquivalentTo(expectedResult);
+            actualResult.Should().BeEquivalentTo(expectedResult);
         }
 
         [Fact]
@@ -758,7 +758,7 @@ namespace DynamicData.Tests.Cache
 
             var list = _results.Messages[1].SortedItems.ToList();
             var sortedResult = list.OrderBy(p => _comparer).ToList();
-            list.ShouldAllBeEquivalentTo(sortedResult);
+            list.Should().BeEquivalentTo(sortedResult);
         }
 
         [Fact]
@@ -779,7 +779,7 @@ namespace DynamicData.Tests.Cache
 
             var list = _results.Messages[1].SortedItems.ToList();
             var sortedResult = list.OrderBy(p => _comparer).ToList();
-            list.ShouldAllBeEquivalentTo(sortedResult);
+            list.Should().BeEquivalentTo(sortedResult);
         }
 
         [Fact]
@@ -800,7 +800,7 @@ namespace DynamicData.Tests.Cache
 
             var list = _results.Messages[1].SortedItems.ToList();
             var sortedResult = list.OrderBy(p => _comparer).ToList();
-            list.ShouldAllBeEquivalentTo(sortedResult);
+            list.Should().BeEquivalentTo(sortedResult);
         }
 
         [Fact]
@@ -822,7 +822,7 @@ namespace DynamicData.Tests.Cache
 
             var list = _results.Messages[1].SortedItems.ToList();
             var sortedResult = list.OrderBy(p => _comparer).ToList();
-            list.ShouldAllBeEquivalentTo(sortedResult);
+            list.Should().BeEquivalentTo(sortedResult);
         }
 
         [Fact]
@@ -843,7 +843,7 @@ namespace DynamicData.Tests.Cache
 
             var list = _results.Messages[1].SortedItems.ToList();
             var sortedResult = list.OrderBy(p => _comparer).ToList();
-            list.ShouldAllBeEquivalentTo(sortedResult);
+            list.Should().BeEquivalentTo(sortedResult);
         }
 
         [Fact]
@@ -864,7 +864,7 @@ namespace DynamicData.Tests.Cache
             ReferenceEquals(update, indexedItem.Value.Value).Should().BeTrue();
             var list = _results.Messages[1].SortedItems.ToList();
             var sortedResult = list.OrderBy(p => _comparer).ToList();
-            list.ShouldAllBeEquivalentTo(sortedResult);
+            list.Should().BeEquivalentTo(sortedResult);
         }
 
         [Fact]
@@ -886,7 +886,7 @@ namespace DynamicData.Tests.Cache
             ReferenceEquals(update, indexedItem.Value.Value).Should().BeTrue();
             var list = _results.Messages[1].SortedItems.ToList();
             var sortedResult = list.OrderBy(p => _comparer).ToList();
-            list.ShouldAllBeEquivalentTo(sortedResult);
+            list.Should().BeEquivalentTo(sortedResult);
         }
 
         [Fact]
@@ -909,7 +909,7 @@ namespace DynamicData.Tests.Cache
             ReferenceEquals(update, indexedItem.Value.Value).Should().BeTrue();
             var list = _results.Messages[1].SortedItems.ToList();
             var sortedResult = list.OrderBy(p => _comparer).ToList();
-            list.ShouldAllBeEquivalentTo(sortedResult);
+            list.Should().BeEquivalentTo(sortedResult);
         }
 
         [Fact]
@@ -934,7 +934,7 @@ namespace DynamicData.Tests.Cache
             adaptor.Adapt(_results.Messages.Last(), list);
 
             var shouldbe = _results.Messages.Last().SortedItems.Select(p => p.Value).ToList();
-            list.ShouldAllBeEquivalentTo(shouldbe);
+            list.Should().BeEquivalentTo(shouldbe);
         }
 
         [Fact]
@@ -960,7 +960,7 @@ namespace DynamicData.Tests.Cache
             adaptor.Adapt(_results.Messages.Last(), list);
 
             var shouldbe = _results.Messages.Last().SortedItems.Select(p => p.Value).ToList();
-            list.ShouldAllBeEquivalentTo(shouldbe);
+            list.Should().BeEquivalentTo(shouldbe);
         }
 
         [Fact]
@@ -984,7 +984,7 @@ namespace DynamicData.Tests.Cache
             adaptor.Adapt(_results.Messages.Last(), list);
 
             var shouldbe = _results.Messages.Last().SortedItems.Select(p => p.Value).ToList();
-            list.ShouldAllBeEquivalentTo(shouldbe);
+            list.Should().BeEquivalentTo(shouldbe);
         }
 
         [Fact]
@@ -1008,7 +1008,7 @@ namespace DynamicData.Tests.Cache
 
             adaptor.Adapt(_results.Messages.Last(), list);
             var shouldbe = _results.Messages.Last().SortedItems.Select(p => p.Value).ToList();
-            list.ShouldAllBeEquivalentTo(shouldbe);
+            list.Should().BeEquivalentTo(shouldbe);
         }
 
         [Fact]
@@ -1039,7 +1039,7 @@ namespace DynamicData.Tests.Cache
 
             adaptor.Adapt(_results.Messages.Last(), list);
             var shouldbe = _results.Messages.Last().SortedItems.Select(p => p.Value).ToList();
-            list.ShouldAllBeEquivalentTo(shouldbe);
+            list.Should().BeEquivalentTo(shouldbe);
         }
 
         [Fact]
@@ -1065,7 +1065,7 @@ namespace DynamicData.Tests.Cache
             adaptor.Adapt(_results.Messages.Last(), list);
 
             var shouldbe = _results.Messages.Last().SortedItems.Select(p => p.Value).ToList();
-            list.ShouldAllBeEquivalentTo(shouldbe);
+            list.Should().BeEquivalentTo(shouldbe);
         }
 
         [Fact]
@@ -1088,7 +1088,7 @@ namespace DynamicData.Tests.Cache
             adaptor.Adapt(_results.Messages.Last(), list);
 
             var shouldbe = _results.Messages.Last().SortedItems.Select(p => p.Value).ToList();
-            list.ShouldAllBeEquivalentTo(shouldbe);
+            list.Should().BeEquivalentTo(shouldbe);
         }
 
         [Fact]
@@ -1105,7 +1105,7 @@ namespace DynamicData.Tests.Cache
             adaptor.Adapt(_results.Messages.Last(), list);
 
             var shouldbe = _results.Messages.Last().SortedItems.Select(p => p.Value).ToList();
-            list.ShouldAllBeEquivalentTo(shouldbe);
+            list.Should().BeEquivalentTo(shouldbe);
         }
     }
 }

--- a/src/DynamicData.Tests/Cache/SortObservableFixtureFixture.cs
+++ b/src/DynamicData.Tests/Cache/SortObservableFixtureFixture.cs
@@ -51,7 +51,7 @@ namespace DynamicData.Tests.Cache
             var expectedResult = people.OrderBy(p => p, _comparer).Select(p => new KeyValuePair<string, Person>(p.Name, p)).ToList();
             var actualResult = _results.Messages[0].SortedItems.ToList();
 
-            actualResult.ShouldAllBeEquivalentTo(expectedResult);
+            actualResult.Should().BeEquivalentTo(expectedResult);
         }
 
         [Fact]
@@ -67,7 +67,7 @@ namespace DynamicData.Tests.Cache
             var actualResult = _results.Messages[0].SortedItems.ToList();
             var movesCount = _results.Messages[0].Moves;
 
-            actualResult.ShouldAllBeEquivalentTo(expectedResult);
+            actualResult.Should().BeEquivalentTo(expectedResult);
         }
 
         [Fact]
@@ -83,7 +83,7 @@ namespace DynamicData.Tests.Cache
             var items = _results.Messages.Last().SortedItems;
             var actualResult = items.ToList();
             var sortReason = items.SortReason;
-            actualResult.ShouldAllBeEquivalentTo(expectedResult);
+            actualResult.Should().BeEquivalentTo(expectedResult);
             sortReason.Should().Be(SortReason.Reorder);
         }
 
@@ -100,7 +100,7 @@ namespace DynamicData.Tests.Cache
             var items = _results.Messages.Last().SortedItems;
             var actualResult = items.ToList();
             var sortReason = items.SortReason;
-            actualResult.ShouldAllBeEquivalentTo(expectedResult);
+            actualResult.Should().BeEquivalentTo(expectedResult);
             sortReason.Should().Be(SortReason.Reset);
         }
 
@@ -120,7 +120,7 @@ namespace DynamicData.Tests.Cache
 
             var expected = people.OrderBy(t => t, _comparer).ToList();
             var actual = _results.Messages.Last().SortedItems.Select(kv => kv.Value).ToList();
-            actual.ShouldAllBeEquivalentTo(expected);
+            actual.Should().BeEquivalentTo(expected);
 
             var list = new ObservableCollectionExtended<Person>();
             var adaptor = new SortedObservableCollectionAdaptor<Person, string>();
@@ -129,7 +129,7 @@ namespace DynamicData.Tests.Cache
                 adaptor.Adapt(message, list);
             }
 
-            list.ShouldAllBeEquivalentTo(expected);
+            list.Should().BeEquivalentTo(expected);
         }
 
         [Fact]
@@ -142,7 +142,7 @@ namespace DynamicData.Tests.Cache
 
             var expectedResult = people.OrderBy(p => p, _comparer).Select(p => new KeyValuePair<string, Person>(p.Name, p)).ToList();
             var actualResult = _results.Messages[2].SortedItems.ToList();
-            actualResult.ShouldAllBeEquivalentTo(expectedResult);
+            actualResult.Should().BeEquivalentTo(expectedResult);
         }
     }
 }

--- a/src/DynamicData.Tests/Cache/TransformAsyncFixture.cs
+++ b/src/DynamicData.Tests/Cache/TransformAsyncFixture.cs
@@ -125,7 +125,7 @@ namespace DynamicData.Tests.Cache
 
         //        var result = await Task.WhenAll(people.Select(stub.TransformFactory));
         //        var transformed = result.OrderBy(p => p.Age).ToArray();
-        //        stub.Results.Data.Items.OrderBy(p => p.Age).ShouldAllBeEquivalentTo(stub.Results.Data.Items.OrderBy(p => p.Age), "Incorrect transform result");
+        //        stub.Results.Data.Items.OrderBy(p => p.Age).Should().BeEquivalentTo(stub.Results.Data.Items.OrderBy(p => p.Age), "Incorrect transform result");
         //    }
         //}
 

--- a/src/DynamicData.Tests/Cache/TransformFixture.cs
+++ b/src/DynamicData.Tests/Cache/TransformFixture.cs
@@ -123,7 +123,7 @@ namespace DynamicData.Tests.Cache
                 stub.Results.Messages[0].Adds.Should().Be(100, "Should return 100 adds");
 
                 var transformed = people.Select(stub.TransformFactory).OrderBy(p => p.Age).ToArray();
-                stub.Results.Data.Items.OrderBy(p => p.Age).ShouldAllBeEquivalentTo(transformed, "Incorrect transform result");
+                stub.Results.Data.Items.OrderBy(p => p.Age).Should().BeEquivalentTo(transformed, "Incorrect transform result");
             }
         }
 

--- a/src/DynamicData.Tests/Cache/TransformFixtureParallel.cs
+++ b/src/DynamicData.Tests/Cache/TransformFixtureParallel.cs
@@ -86,7 +86,7 @@ namespace DynamicData.Tests.Cache
 
             var transformed = people.Select(_transformFactory).ToArray();
 
-            _results.Data.Items.OrderBy(p => p.Age).ShouldAllBeEquivalentTo(transformed, "Incorrect transform result");
+            _results.Data.Items.OrderBy(p => p.Age).Should().BeEquivalentTo(transformed, "Incorrect transform result");
         }
 
         [Fact]

--- a/src/DynamicData.Tests/Cache/TransformSafeAsyncFixture.cs
+++ b/src/DynamicData.Tests/Cache/TransformSafeAsyncFixture.cs
@@ -131,7 +131,7 @@ namespace DynamicData.Tests.Cache
 
         //        var result = await Task.WhenAll(people.Select(stub.TransformFactory));
         //        var transformed = result.OrderBy(p => p.Age).ToArray();
-        //        stub.Results.Data.Items.OrderBy(p => p.Age).ShouldAllBeEquivalentTo(stub.Results.Data.Items.OrderBy(p => p.Age), "Incorrect transform result");
+        //        stub.Results.Data.Items.OrderBy(p => p.Age).Should().BeEquivalentTo(stub.Results.Data.Items.OrderBy(p => p.Age), "Incorrect transform result");
         //    }
         //}
 

--- a/src/DynamicData.Tests/DynamicData.Tests.csproj
+++ b/src/DynamicData.Tests/DynamicData.Tests.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.console" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2" />
-    <PackageReference Include="FluentAssertions" Version="4.19.4" />
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.Reactive.Testing" Version="4.4.1" />
   </ItemGroup>
 </Project>

--- a/src/DynamicData.Tests/EnumerableExFixtures.cs
+++ b/src/DynamicData.Tests/EnumerableExFixtures.cs
@@ -17,7 +17,7 @@ namespace DynamicData.Tests
             var source = new[] {_person1, _person2, _person3};
             var changeSet = source.AsObservableChangeSet(x => x.Age)
                 .AsObservableCache();
-            changeSet.Items.ShouldBeEquivalentTo(source);
+            changeSet.Items.Should().BeEquivalentTo(source);
         }
 
         [Fact]
@@ -26,7 +26,7 @@ namespace DynamicData.Tests
             var source = new[] {_person1, _person2, _person3};
             var changeSet = source.AsObservableChangeSet()
                 .AsObservableList();
-            changeSet.Items.ShouldBeEquivalentTo(source);
+            changeSet.Items.Should().BeEquivalentTo(source);
         }
 
         [Theory]

--- a/src/DynamicData.Tests/Kernal/SourceUpdaterFixture.cs
+++ b/src/DynamicData.Tests/Kernal/SourceUpdaterFixture.cs
@@ -49,7 +49,7 @@ namespace DynamicData.Tests.Kernal
             _updater.AddOrUpdate(people);
             var updates = _cache.CaptureChanges();
 
-            _cache.Items.ToArray().ShouldAllBeEquivalentTo(people);
+            _cache.Items.ToArray().Should().BeEquivalentTo(people);
             _cache.Count.Should().Be(100);
             updates.Adds.Should().Be(100);
             updates.Count.Should().Be(100);

--- a/src/DynamicData.Tests/List/AndFixture.cs
+++ b/src/DynamicData.Tests/List/AndFixture.cs
@@ -76,7 +76,7 @@ namespace DynamicData.Tests.List
             _source1.AddRange(Enumerable.Range(1, 10));
             _source2.AddRange(Enumerable.Range(6, 10));
             _results.Data.Count.Should().Be(5);
-            _results.Data.Items.ShouldAllBeEquivalentTo(Enumerable.Range(6, 5));
+            _results.Data.Items.Should().BeEquivalentTo(Enumerable.Range(6, 5));
         }
 
         [Fact]

--- a/src/DynamicData.Tests/List/AutoRefreshFixture.cs
+++ b/src/DynamicData.Tests/List/AutoRefreshFixture.cs
@@ -189,7 +189,7 @@ namespace DynamicData.Tests.List
                 void CheckOrder()
                 {
                     var sorted = items.OrderBy(p => p, comparer).ToArray();
-                    results.Data.Items.ShouldAllBeEquivalentTo(sorted);
+                    results.Data.Items.Should().BeEquivalentTo(sorted);
                 }
 
                 list.AddRange(items);
@@ -245,7 +245,7 @@ namespace DynamicData.Tests.List
                         var childGroup = results.Data.Items.Single(g => g.GroupKey == grouping.Key);
                         var expected = grouping.OrderBy(p => p.Name);
                         var actual = childGroup.List.Items.OrderBy(p => p.Name);
-                        actual.ShouldAllBeEquivalentTo(expected);
+                        actual.Should().BeEquivalentTo(expected);
                     }
                 }
 
@@ -306,7 +306,7 @@ namespace DynamicData.Tests.List
                         var childGroup = results.Data.Items.Single(g => g.Key == grouping.Key);
                         var expected = grouping.OrderBy(p => p.Name);
                         var actual = childGroup.Items.OrderBy(p => p.Name);
-                        actual.ShouldAllBeEquivalentTo(expected);
+                        actual.Should().BeEquivalentTo(expected);
                     }
                 }
 

--- a/src/DynamicData.Tests/List/ChangeAwareListFixture.cs
+++ b/src/DynamicData.Tests/List/ChangeAwareListFixture.cs
@@ -28,7 +28,7 @@ namespace DynamicData.Tests.List
             changes.First().Item.Current.Should().Be(1);
 
             //assert collection
-            _list.ShouldAllBeEquivalentTo(Enumerable.Range(1, 1));
+            _list.Should().BeEquivalentTo(Enumerable.Range(1, 1));
         }
 
         [Fact]
@@ -45,7 +45,7 @@ namespace DynamicData.Tests.List
             changes.Adds.Should().Be(1);
             changes.First().Item.Current.Should().Be(2);
             //assert collection
-            _list.ShouldBeEquivalentTo(Enumerable.Range(1, 2));
+            _list.Should().BeEquivalentTo(Enumerable.Range(1, 2));
         }
 
         [Fact]
@@ -58,9 +58,9 @@ namespace DynamicData.Tests.List
             var changes = _list.CaptureChanges();
             changes.Count.Should().Be(1);
             changes.Adds.Should().Be(10);
-            changes.First().Range.ShouldAllBeEquivalentTo(Enumerable.Range(1, 10));
+            changes.First().Range.Should().BeEquivalentTo(Enumerable.Range(1, 10));
             //assert collection
-            _list.ShouldAllBeEquivalentTo(Enumerable.Range(1, 10));
+            _list.Should().BeEquivalentTo(Enumerable.Range(1, 10));
         }
 
         [Fact]
@@ -72,10 +72,10 @@ namespace DynamicData.Tests.List
             var changes = _list.CaptureChanges();
             changes.Count.Should().Be(1);
             changes.Adds.Should().Be(10);
-            changes.First().Range.ShouldAllBeEquivalentTo(Enumerable.Range(1, 10));
+            changes.First().Range.Should().BeEquivalentTo(Enumerable.Range(1, 10));
 
             //assert collection
-            _list.ShouldAllBeEquivalentTo(Enumerable.Range(1, 10));
+            _list.Should().BeEquivalentTo(Enumerable.Range(1, 10));
         }
 
         [Fact]
@@ -88,11 +88,11 @@ namespace DynamicData.Tests.List
             //assert changes
             changes.Count.Should().Be(2);
             changes.Adds.Should().Be(20);
-            changes.First().Range.ShouldBeEquivalentTo(Enumerable.Range(1, 10));
-            changes.Skip(1).First().Range.ShouldBeEquivalentTo(Enumerable.Range(11, 10));
+            changes.First().Range.Should().BeEquivalentTo(Enumerable.Range(1, 10));
+            changes.Skip(1).First().Range.Should().BeEquivalentTo(Enumerable.Range(11, 10));
 
             //assert collection
-            _list.ShouldAllBeEquivalentTo(Enumerable.Range(1, 20));
+            _list.Should().BeEquivalentTo(Enumerable.Range(1, 20));
         }
 
         [Fact]
@@ -105,14 +105,14 @@ namespace DynamicData.Tests.List
             //assert changes
             changes.Count.Should().Be(2);
             changes.Adds.Should().Be(20);
-            changes.First().Range.ShouldAllBeEquivalentTo(Enumerable.Range(1, 10));
-            changes.Skip(1).First().Range.ShouldAllBeEquivalentTo(Enumerable.Range(11, 10));
+            changes.First().Range.Should().BeEquivalentTo(Enumerable.Range(1, 10));
+            changes.Skip(1).First().Range.Should().BeEquivalentTo(Enumerable.Range(11, 10));
 
             var shouldBe = Enumerable.Range(1, 5)
                                      .Union(Enumerable.Range(11, 10))
                                      .Union(Enumerable.Range(6, 5));
             //assert collection
-            _list.ShouldAllBeEquivalentTo(shouldBe);
+            _list.Should().BeEquivalentTo(shouldBe);
         }
 
         [Fact]
@@ -144,13 +144,13 @@ namespace DynamicData.Tests.List
             var changes = _list.CaptureChanges();
             changes.Count.Should().Be(1);
             changes.Removes.Should().Be(3);
-            changes.First().Range.ShouldAllBeEquivalentTo(Enumerable.Range(6, 3));
+            changes.First().Range.Should().BeEquivalentTo(Enumerable.Range(6, 3));
 
             //assert collection
             var shouldBe = Enumerable.Range(1, 5)
                                      .Union(Enumerable.Range(9, 2));
             //assert collection
-            _list.ShouldAllBeEquivalentTo(shouldBe);
+            _list.Should().BeEquivalentTo(shouldBe);
         }
 
         [Fact]
@@ -165,7 +165,7 @@ namespace DynamicData.Tests.List
             var changes = _list.CaptureChanges();
             changes.Count.Should().Be(1);
             changes.Removes.Should().Be(10);
-            changes.First().Range.ShouldAllBeEquivalentTo(Enumerable.Range(1, 10));
+            changes.First().Range.Should().BeEquivalentTo(Enumerable.Range(1, 10));
 
             //assert collection
             _list.Count.Should().Be(0);
@@ -183,7 +183,7 @@ namespace DynamicData.Tests.List
             var changes = _list.CaptureChanges();
             changes.Count.Should().Be(1);
             changes.Removes.Should().Be(10);
-            changes.First().Range.ShouldAllBeEquivalentTo(Enumerable.Range(1, 10));
+            changes.First().Range.Should().BeEquivalentTo(Enumerable.Range(1, 10));
             //assert collection
             _list.Count.Should().Be(0);
         }
@@ -200,7 +200,7 @@ namespace DynamicData.Tests.List
             var changes = _list.CaptureChanges();
             changes.Count.Should().Be(1);
             changes.Removes.Should().Be(10);
-            changes.First().Range.ShouldAllBeEquivalentTo(Enumerable.Range(1, 10));
+            changes.First().Range.Should().BeEquivalentTo(Enumerable.Range(1, 10));
 
             //assert collection
             _list.Count.Should().Be(0);

--- a/src/DynamicData.Tests/List/CloneChangesFixture.cs
+++ b/src/DynamicData.Tests/List/CloneChangesFixture.cs
@@ -28,7 +28,7 @@ namespace DynamicData.Tests.List
             _clone.Clone(changes);
 
             //assert collection
-            _clone.ShouldAllBeEquivalentTo(_source);
+            _clone.Should().BeEquivalentTo(_source);
         }
 
         [Fact]
@@ -39,7 +39,7 @@ namespace DynamicData.Tests.List
 
             var changes = _source.CaptureChanges();
             _clone.Clone(changes);
-            _clone.ShouldAllBeEquivalentTo(_source);
+            _clone.Should().BeEquivalentTo(_source);
         }
 
         [Fact]
@@ -50,7 +50,7 @@ namespace DynamicData.Tests.List
 
             var changes = _source.CaptureChanges();
             _clone.Clone(changes);
-            _clone.ShouldAllBeEquivalentTo(_source);
+            _clone.Should().BeEquivalentTo(_source);
         }
 
         [Fact]
@@ -60,7 +60,7 @@ namespace DynamicData.Tests.List
 
             var changes = _source.CaptureChanges();
             _clone.Clone(changes);
-            _clone.ShouldAllBeEquivalentTo(_source);
+            _clone.Should().BeEquivalentTo(_source);
         }
 
         [Fact]
@@ -70,7 +70,7 @@ namespace DynamicData.Tests.List
             _source.AddRange(Enumerable.Range(11, 10));
             var changes = _source.CaptureChanges();
             _clone.Clone(changes);
-            _clone.ShouldAllBeEquivalentTo(_source);
+            _clone.Should().BeEquivalentTo(_source);
         }
 
         [Fact]
@@ -81,7 +81,7 @@ namespace DynamicData.Tests.List
 
             var changes = _source.CaptureChanges();
             _clone.Clone(changes);
-            _clone.ShouldAllBeEquivalentTo(_source);
+            _clone.Should().BeEquivalentTo(_source);
         }
 
         [Fact]
@@ -92,7 +92,7 @@ namespace DynamicData.Tests.List
 
             var changes = _source.CaptureChanges();
             _clone.Clone(changes);
-            _clone.ShouldAllBeEquivalentTo(_source);
+            _clone.Should().BeEquivalentTo(_source);
         }
 
         [Fact]
@@ -103,7 +103,7 @@ namespace DynamicData.Tests.List
 
             var changes = _source.CaptureChanges();
             _clone.Clone(changes);
-            _clone.ShouldAllBeEquivalentTo(_source);
+            _clone.Should().BeEquivalentTo(_source);
         }
 
         [Fact]
@@ -115,7 +115,7 @@ namespace DynamicData.Tests.List
             _source.ToArray().ForEach(i => _source.Remove(i));
             var changes = _source.CaptureChanges();
             _clone.Clone(changes);
-            _clone.ShouldAllBeEquivalentTo(_source);
+            _clone.Should().BeEquivalentTo(_source);
         }
 
         [Fact]
@@ -128,7 +128,7 @@ namespace DynamicData.Tests.List
 
             var changes = _source.CaptureChanges();
             _clone.Clone(changes);
-            _clone.ShouldAllBeEquivalentTo(_source);
+            _clone.Should().BeEquivalentTo(_source);
         }
 
         [Fact]
@@ -139,7 +139,7 @@ namespace DynamicData.Tests.List
             _source.RemoveMany(Enumerable.Range(1, 10));
             var changes = _source.CaptureChanges();
             _clone.Clone(changes);
-            _clone.ShouldAllBeEquivalentTo(_source);
+            _clone.Should().BeEquivalentTo(_source);
         }
 
         [Fact]
@@ -150,7 +150,7 @@ namespace DynamicData.Tests.List
             _source.RemoveRange(5, 3);
             var changes = _source.CaptureChanges();
             _clone.Clone(changes);
-            _clone.ShouldAllBeEquivalentTo(_source);
+            _clone.Should().BeEquivalentTo(_source);
         }
 
         [Fact]
@@ -161,7 +161,7 @@ namespace DynamicData.Tests.List
             _source.RemoveMany(Enumerable.Range(3, 5));
             var changes = _source.CaptureChanges();
             _clone.Clone(changes);
-            _clone.ShouldAllBeEquivalentTo(_source);
+            _clone.Should().BeEquivalentTo(_source);
         }
 
         [Fact]

--- a/src/DynamicData.Tests/List/CloneFixture.cs
+++ b/src/DynamicData.Tests/List/CloneFixture.cs
@@ -71,7 +71,7 @@ namespace DynamicData.Tests.List
             _source.AddOrUpdate(people);
 
             _collection.Count.Should().Be(100, "Should be 100 items in the collection");
-            _collection.ShouldAllBeEquivalentTo(_collection, "Collections should be equivalent");
+            _collection.Should().BeEquivalentTo(_collection, "Collections should be equivalent");
         }
 
         [Fact]

--- a/src/DynamicData.Tests/List/DistinctValuesFixture.cs
+++ b/src/DynamicData.Tests/List/DistinctValuesFixture.cs
@@ -47,7 +47,7 @@ namespace DynamicData.Tests.List
             _results.Messages.Count.Should().Be(1, "Should be 1 updates");
             _results.Data.Count.Should().Be(3, "Should be 3 items in the cache");
 
-            _results.Data.Items.ShouldAllBeEquivalentTo(new[] {20, 21, 22});
+            _results.Data.Items.Should().BeEquivalentTo(new[] {20, 21, 22});
             _results.Data.Items.First().Should().Be(20, "Should 20");
         }
 
@@ -107,7 +107,7 @@ namespace DynamicData.Tests.List
             _results.Messages.Count.Should().Be(3, "Should be 2 updates");
             _results.Data.Count.Should().Be(1, "Should be 1 item in the cache");
 
-            _results.Data.Items.ShouldAllBeEquivalentTo(new[] { 20 });
+            _results.Data.Items.Should().BeEquivalentTo(new[] { 20 });
             _results.Messages.ElementAt(0).Adds.Should().Be(1, "First message should be an add");
             _results.Messages.ElementAt(1).Removes.Should().Be(1, "Second message should be a remove");
             _results.Messages.ElementAt(2).Adds.Should().Be(1, "Third message should be an add");

--- a/src/DynamicData.Tests/List/DynamicAndFixture.cs
+++ b/src/DynamicData.Tests/List/DynamicAndFixture.cs
@@ -71,7 +71,7 @@ namespace DynamicData.Tests.List
             _source1.AddRange(Enumerable.Range(1, 10));
             _source2.AddRange(Enumerable.Range(6, 10));
             _results.Data.Count.Should().Be(5);
-            _results.Data.Items.ShouldAllBeEquivalentTo(Enumerable.Range(6, 5));
+            _results.Data.Items.Should().BeEquivalentTo(Enumerable.Range(6, 5));
         }
 
         [Fact]
@@ -97,7 +97,7 @@ namespace DynamicData.Tests.List
             var result = Enumerable.Range(1, 5).ToArray();
 
             _results.Data.Count.Should().Be(5);
-            _results.Data.Items.ShouldAllBeEquivalentTo(result);
+            _results.Data.Items.Should().BeEquivalentTo(result);
 
             _source2.AddRange(Enumerable.Range(6, 5));
             _results.Data.Count.Should().Be(5);
@@ -107,7 +107,7 @@ namespace DynamicData.Tests.List
 
             _source.RemoveAt(2);
             _results.Data.Count.Should().Be(5);
-            _results.Data.Items.ShouldAllBeEquivalentTo(result);
+            _results.Data.Items.Should().BeEquivalentTo(result);
         }
     }
 }

--- a/src/DynamicData.Tests/List/DynamicExceptFixture.cs
+++ b/src/DynamicData.Tests/List/DynamicExceptFixture.cs
@@ -80,7 +80,7 @@ namespace DynamicData.Tests.List
             _source1.AddRange(Enumerable.Range(1, 10));
             _source2.AddRange(Enumerable.Range(6, 10));
             _results.Data.Count.Should().Be(5);
-            _results.Data.Items.ShouldAllBeEquivalentTo(Enumerable.Range(1, 5));
+            _results.Data.Items.Should().BeEquivalentTo(Enumerable.Range(1, 5));
         }
 
         [Fact]
@@ -105,7 +105,7 @@ namespace DynamicData.Tests.List
             _results.Data.Count.Should().Be(0);
             _source2.Clear();
             _results.Data.Count.Should().Be(5);
-            _results.Data.Items.ShouldAllBeEquivalentTo(Enumerable.Range(1, 5));
+            _results.Data.Items.Should().BeEquivalentTo(Enumerable.Range(1, 5));
         }
 
         [Fact]
@@ -121,7 +121,7 @@ namespace DynamicData.Tests.List
 
             var result = Enumerable.Range(1, 5);
             _results.Data.Count.Should().Be(5);
-            _results.Data.Items.ShouldAllBeEquivalentTo(result);
+            _results.Data.Items.Should().BeEquivalentTo(result);
 
             _source2.Edit(innerList =>
             {
@@ -131,23 +131,23 @@ namespace DynamicData.Tests.List
 
             result = Enumerable.Range(1, 2);
             _results.Data.Count.Should().Be(2);
-            _results.Data.Items.ShouldAllBeEquivalentTo(result);
+            _results.Data.Items.Should().BeEquivalentTo(result);
 
             _source.RemoveAt(1);
             result = Enumerable.Range(1, 5);
             _results.Data.Count.Should().Be(5);
-            _results.Data.Items.ShouldAllBeEquivalentTo(result);
+            _results.Data.Items.Should().BeEquivalentTo(result);
 
             _source.Add(_source2.Connect());
             result = Enumerable.Range(1, 2);
             _results.Data.Count.Should().Be(2);
-            _results.Data.Items.ShouldAllBeEquivalentTo(result);
+            _results.Data.Items.Should().BeEquivalentTo(result);
 
             //remove root except
             _source.RemoveAt(0);
             result = Enumerable.Range(100, 5);
             _results.Data.Count.Should().Be(5);
-            _results.Data.Items.ShouldAllBeEquivalentTo(result);
+            _results.Data.Items.Should().BeEquivalentTo(result);
         }
     }
 }

--- a/src/DynamicData.Tests/List/DynamicOrFixture.cs
+++ b/src/DynamicData.Tests/List/DynamicOrFixture.cs
@@ -121,7 +121,7 @@ namespace DynamicData.Tests.List
             _source1.AddRange(Enumerable.Range(1, 5));
             _source2.AddRange(Enumerable.Range(6, 5));
             _results.Data.Count.Should().Be(10);
-            _results.Data.Items.ShouldAllBeEquivalentTo(Enumerable.Range(1, 10));
+            _results.Data.Items.Should().BeEquivalentTo(Enumerable.Range(1, 10));
         }
 
         [Fact]
@@ -133,7 +133,7 @@ namespace DynamicData.Tests.List
             _source2.AddRange(Enumerable.Range(6, 5));
             _source1.Clear();
             _results.Data.Count.Should().Be(5);
-            _results.Data.Items.ShouldAllBeEquivalentTo(Enumerable.Range(6, 5));
+            _results.Data.Items.Should().BeEquivalentTo(Enumerable.Range(6, 5));
         }
 
         [Fact]
@@ -150,13 +150,13 @@ namespace DynamicData.Tests.List
             var result = Enumerable.Range(1, 5).Union(Enumerable.Range(6, 5)).Union(Enumerable.Range(100, 5));
 
             _results.Data.Count.Should().Be(15);
-            _results.Data.Items.ShouldAllBeEquivalentTo(result);
+            _results.Data.Items.Should().BeEquivalentTo(result);
 
             _source.RemoveAt(1);
             _results.Data.Count.Should().Be(10);
 
             result = Enumerable.Range(1, 5).Union(Enumerable.Range(100, 5));
-            _results.Data.Items.ShouldAllBeEquivalentTo(result);
+            _results.Data.Items.Should().BeEquivalentTo(result);
         }
 
         [Fact]

--- a/src/DynamicData.Tests/List/DynamicXOrFixture.cs
+++ b/src/DynamicData.Tests/List/DynamicXOrFixture.cs
@@ -83,7 +83,7 @@ namespace DynamicData.Tests.List
             _source1.AddRange(Enumerable.Range(1, 5));
             _source2.AddRange(Enumerable.Range(6, 5));
             _results.Data.Count.Should().Be(10);
-            _results.Data.Items.ShouldAllBeEquivalentTo(Enumerable.Range(1, 10));
+            _results.Data.Items.Should().BeEquivalentTo(Enumerable.Range(1, 10));
         }
 
         [Fact]
@@ -95,7 +95,7 @@ namespace DynamicData.Tests.List
             _source2.AddRange(Enumerable.Range(6, 5));
             _source1.Clear();
             _results.Data.Count.Should().Be(5);
-            _results.Data.Items.ShouldAllBeEquivalentTo(Enumerable.Range(6, 5));
+            _results.Data.Items.Should().BeEquivalentTo(Enumerable.Range(6, 5));
         }
 
         [Fact]
@@ -107,7 +107,7 @@ namespace DynamicData.Tests.List
             _source2.AddRange(Enumerable.Range(6, 10));
 
             _results.Data.Count.Should().Be(10);
-            _results.Data.Items.ShouldAllBeEquivalentTo(Enumerable.Range(1, 5).Union(Enumerable.Range(11, 5)));
+            _results.Data.Items.Should().BeEquivalentTo(Enumerable.Range(1, 5).Union(Enumerable.Range(11, 5)));
         }
 
         [Fact]
@@ -123,17 +123,17 @@ namespace DynamicData.Tests.List
 
             var result = Enumerable.Range(6, 5);
             _results.Data.Count.Should().Be(5);
-            _results.Data.Items.ShouldAllBeEquivalentTo(result);
+            _results.Data.Items.Should().BeEquivalentTo(result);
 
             _source.RemoveAt(0);
             result = Enumerable.Range(1, 5).Union(Enumerable.Range(6, 5));
             _results.Data.Count.Should().Be(10);
-            _results.Data.Items.ShouldAllBeEquivalentTo(result);
+            _results.Data.Items.Should().BeEquivalentTo(result);
 
             _source.Add(_source1.Connect());
             result = Enumerable.Range(6, 5);
             _results.Data.Count.Should().Be(5);
-            _results.Data.Items.ShouldAllBeEquivalentTo(result);
+            _results.Data.Items.Should().BeEquivalentTo(result);
         }
     }
 }

--- a/src/DynamicData.Tests/List/EditDiffFixture.cs
+++ b/src/DynamicData.Tests/List/EditDiffFixture.cs
@@ -33,7 +33,7 @@ namespace DynamicData.Tests.List
             _cache.EditDiff(newPeople, Person.NameAgeGenderComparer);
 
             _cache.Count.Should().Be(15);
-            _cache.Items.ShouldAllBeEquivalentTo(newPeople);
+            _cache.Items.Should().BeEquivalentTo(newPeople);
             var lastChange = _result.Messages.Last();
             lastChange.Adds.Should().Be(5);
         }
@@ -46,7 +46,7 @@ namespace DynamicData.Tests.List
             _cache.EditDiff(newPeople, Person.NameAgeGenderComparer);
 
             _cache.Count.Should().Be(10);
-            _cache.Items.ShouldAllBeEquivalentTo(newPeople);
+            _cache.Items.Should().BeEquivalentTo(newPeople);
             _result.Messages.Count.Should().Be(1);
         }
 
@@ -62,7 +62,7 @@ namespace DynamicData.Tests.List
             lastChange.Adds.Should().Be(3);
             lastChange.Removes.Should().Be(10);
 
-            _cache.Items.ShouldAllBeEquivalentTo(newList);
+            _cache.Items.Should().BeEquivalentTo(newList);
         }
 
         [Fact]
@@ -77,7 +77,7 @@ namespace DynamicData.Tests.List
             lastChange.Adds.Should().Be(0);
             lastChange.Removes.Should().Be(3);
 
-            _cache.Items.ShouldAllBeEquivalentTo(newList);
+            _cache.Items.Should().BeEquivalentTo(newList);
         }
 
         [Fact]
@@ -93,7 +93,7 @@ namespace DynamicData.Tests.List
             lastChange.Adds.Should().Be(5);
             lastChange.Removes.Should().Be(5);
 
-            _cache.Items.ShouldAllBeEquivalentTo(newList);
+            _cache.Items.Should().BeEquivalentTo(newList);
         }
     }
 }

--- a/src/DynamicData.Tests/List/ExceptFixture.cs
+++ b/src/DynamicData.Tests/List/ExceptFixture.cs
@@ -83,7 +83,7 @@ namespace DynamicData.Tests.List
             Source1.AddRange(Enumerable.Range(1, 10));
             Source2.AddRange(Enumerable.Range(6, 10));
             _results.Data.Count.Should().Be(5);
-            _results.Data.Items.ShouldAllBeEquivalentTo(Enumerable.Range(1, 5));
+            _results.Data.Items.Should().BeEquivalentTo(Enumerable.Range(1, 5));
         }
 
         [Fact]
@@ -103,7 +103,7 @@ namespace DynamicData.Tests.List
             _results.Data.Count.Should().Be(0);
             Source2.Clear();
             _results.Data.Count.Should().Be(5);
-            _results.Data.Items.ShouldAllBeEquivalentTo(Enumerable.Range(1, 5));
+            _results.Data.Items.Should().BeEquivalentTo(Enumerable.Range(1, 5));
         }
     }
 }

--- a/src/DynamicData.Tests/List/FilterControllerFixtureWithClearAndReplace.cs
+++ b/src/DynamicData.Tests/List/FilterControllerFixtureWithClearAndReplace.cs
@@ -147,7 +147,7 @@ namespace DynamicData.Tests.List
             _results.Messages[0].Adds.Should().Be(80, "Should return 80 adds");
 
             var filtered = people.Where(p => p.Age > 20).OrderBy(p => p.Age).ToArray();
-            _results.Data.Items.OrderBy(p => p.Age).ShouldAllBeEquivalentTo(filtered, "Incorrect Filter result");
+            _results.Data.Items.OrderBy(p => p.Age).Should().BeEquivalentTo(filtered, "Incorrect Filter result");
         }
 
         [Fact]
@@ -177,7 +177,7 @@ namespace DynamicData.Tests.List
             _results.Messages.Count.Should().Be(80, "Should be 80 messages");
             _results.Data.Count.Should().Be(80, "Should be 80 in the cache");
             var filtered = people.Where(p => p.Age > 20).OrderBy(p => p.Age).ToArray();
-            _results.Data.Items.OrderBy(p => p.Age).ShouldAllBeEquivalentTo(filtered, "Incorrect Filter result");
+            _results.Data.Items.OrderBy(p => p.Age).Should().BeEquivalentTo(filtered, "Incorrect Filter result");
         }
 
         [Fact]

--- a/src/DynamicData.Tests/List/FilterControllerFixtureWithDiffSet.cs
+++ b/src/DynamicData.Tests/List/FilterControllerFixtureWithDiffSet.cs
@@ -133,7 +133,7 @@ namespace DynamicData.Tests.List
             _results.Messages[0].Adds.Should().Be(80, "Should return 80 adds");
 
             var filtered = people.Where(p => p.Age > 20).OrderBy(p => p.Age).ToArray();
-            _results.Data.Items.OrderBy(p => p.Age).ShouldAllBeEquivalentTo(filtered, "Incorrect Filter result");
+            _results.Data.Items.OrderBy(p => p.Age).Should().BeEquivalentTo(filtered, "Incorrect Filter result");
         }
 
         [Fact]
@@ -163,7 +163,7 @@ namespace DynamicData.Tests.List
             _results.Messages.Count.Should().Be(80, "Should be 80 messages");
             _results.Data.Count.Should().Be(80, "Should be 80 in the cache");
             var filtered = people.Where(p => p.Age > 20).OrderBy(p => p.Age).ToArray();
-            _results.Data.Items.OrderBy(p => p.Age).ShouldAllBeEquivalentTo(filtered, "Incorrect Filter result");
+            _results.Data.Items.OrderBy(p => p.Age).Should().BeEquivalentTo(filtered, "Incorrect Filter result");
         }
 
         [Fact]

--- a/src/DynamicData.Tests/List/FilterFixture.cs
+++ b/src/DynamicData.Tests/List/FilterFixture.cs
@@ -128,7 +128,7 @@ namespace DynamicData.Tests.List
             _results.Messages[0].Adds.Should().Be(80, "Should return 80 adds");
 
             var filtered = people.Where(p => p.Age > 20).OrderBy(p => p.Age).ToArray();
-            _results.Data.Items.OrderBy(p => p.Age).ShouldAllBeEquivalentTo(filtered, "Incorrect Filter result");
+            _results.Data.Items.OrderBy(p => p.Age).Should().BeEquivalentTo(filtered, "Incorrect Filter result");
         }
 
         [Fact]
@@ -157,7 +157,7 @@ namespace DynamicData.Tests.List
             _results.Messages.Count.Should().Be(80, "Should be 80 updates");
             _results.Data.Count.Should().Be(80, "Should be 100 in the cache");
             var filtered = people.Where(p => p.Age > 20).OrderBy(p => p.Age).ToArray();
-            _results.Data.Items.OrderBy(p => p.Age).ShouldAllBeEquivalentTo(filtered, "Incorrect Filter result");
+            _results.Data.Items.OrderBy(p => p.Age).Should().BeEquivalentTo(filtered, "Incorrect Filter result");
         }
 
         [Fact]

--- a/src/DynamicData.Tests/List/FilterOnObservableFixture.cs
+++ b/src/DynamicData.Tests/List/FilterOnObservableFixture.cs
@@ -25,7 +25,7 @@ namespace DynamicData.Tests.List
                 // initial addrange, refreshes to filter out < 18
                // stub.Results.Messages.Count.Should().Be(1+18);
 
-                stub.Results.Data.Items.ShouldAllBeEquivalentTo(people.Skip(18));
+                stub.Results.Data.Items.Should().BeEquivalentTo(people.Skip(18));
             }
         }
 

--- a/src/DynamicData.Tests/List/FilterOnPropertyFixture.cs
+++ b/src/DynamicData.Tests/List/FilterOnPropertyFixture.cs
@@ -20,7 +20,7 @@ namespace DynamicData.Tests.List
                 1.Should().Be(stub.Results.Messages.Count);
                 82.Should().Be(stub.Results.Data.Count);
 
-                stub.Results.Data.Items.ShouldAllBeEquivalentTo(people.Skip(18));
+                stub.Results.Data.Items.Should().BeEquivalentTo(people.Skip(18));
             }
         }
 

--- a/src/DynamicData.Tests/List/FilterWithObservable.cs
+++ b/src/DynamicData.Tests/List/FilterWithObservable.cs
@@ -188,7 +188,7 @@ namespace DynamicData.Tests.List
             _results.Messages[0].Adds.Should().Be(80, "Should return 80 adds");
 
             var filtered = people.Where(p => p.Age > 20).OrderBy(p => p.Age).ToArray();
-            _results.Data.Items.OrderBy(p => p.Age).ShouldAllBeEquivalentTo(filtered, "Incorrect Filter result");
+            _results.Data.Items.OrderBy(p => p.Age).Should().BeEquivalentTo(filtered, "Incorrect Filter result");
         }
 
         [Fact]
@@ -218,7 +218,7 @@ namespace DynamicData.Tests.List
             _results.Messages.Count.Should().Be(80, "Should be 80 messages");
             _results.Data.Count.Should().Be(80, "Should be 80 in the cache");
             var filtered = people.Where(p => p.Age > 20).OrderBy(p => p.Age).ToArray();
-            _results.Data.Items.OrderBy(p => p.Age).ShouldAllBeEquivalentTo(filtered, "Incorrect Filter result");
+            _results.Data.Items.OrderBy(p => p.Age).Should().BeEquivalentTo(filtered, "Incorrect Filter result");
         }
 
         [Fact]

--- a/src/DynamicData.Tests/List/GroupImmutableFixture.cs
+++ b/src/DynamicData.Tests/List/GroupImmutableFixture.cs
@@ -129,7 +129,7 @@ namespace DynamicData.Tests.List
                 .ForEach(group =>
                 {
                     var grp = _results.Data.Items.First(g=> g.Key.Equals(group.Key));
-                    grp.Items.ShouldAllBeEquivalentTo(group.ToArray());
+                    grp.Items.Should().BeEquivalentTo(group.ToArray());
                 });
 
             _source.RemoveMany(initialPeople.Take(15));
@@ -139,7 +139,7 @@ namespace DynamicData.Tests.List
                 .ForEach(group =>
                 {
                     var list = _results.Data.Items.First(p => p.Key == group.Key);
-                    list.Items.ShouldAllBeEquivalentTo(group);
+                    list.Items.Should().BeEquivalentTo(group);
                 });
 
             _results.Messages.Count.Should().Be(2);
@@ -170,7 +170,7 @@ namespace DynamicData.Tests.List
                 .ForEach(groupContainer =>
                 {
                     var grouping = _results.Data.Items.First(g => g.Key == groupContainer.Key);
-                    grouping.Items.ShouldAllBeEquivalentTo(groupContainer);
+                    grouping.Items.Should().BeEquivalentTo(groupContainer);
 
                 });
 

--- a/src/DynamicData.Tests/List/MergeManyChangeSetsFixture.cs
+++ b/src/DynamicData.Tests/List/MergeManyChangeSetsFixture.cs
@@ -33,13 +33,13 @@ namespace DynamicData.Tests.List
             3.Should().Be(d.Count);
             b.Add(5);
             4.Should().Be(d.Count);
-            new[] {1, 2, 3, 5}.ShouldAllBeEquivalentTo(d.Items);
+            new[] {1, 2, 3, 5}.Should().BeEquivalentTo(d.Items);
 
             b.Clear();
 
             // Fails below
             2.Should().Be(d.Count);
-            new[] {1, 2}.ShouldAllBeEquivalentTo(d.Items);
+            new[] {1, 2}.Should().BeEquivalentTo(d.Items);
         }
     }
 }

--- a/src/DynamicData.Tests/List/OrFixture.cs
+++ b/src/DynamicData.Tests/List/OrFixture.cs
@@ -123,7 +123,7 @@ namespace DynamicData.Tests.List
             _source1.AddRange(Enumerable.Range(1, 5));
             _source2.AddRange(Enumerable.Range(6, 5));
             _results.Data.Count.Should().Be(10);
-            _results.Data.Items.ShouldAllBeEquivalentTo(Enumerable.Range(1, 10));
+            _results.Data.Items.Should().BeEquivalentTo(Enumerable.Range(1, 10));
         }
 
         [Fact]
@@ -133,7 +133,7 @@ namespace DynamicData.Tests.List
             _source2.AddRange(Enumerable.Range(6, 5));
             _source1.Clear();
             _results.Data.Count.Should().Be(5);
-            _results.Data.Items.ShouldAllBeEquivalentTo(Enumerable.Range(6, 5));
+            _results.Data.Items.Should().BeEquivalentTo(Enumerable.Range(6, 5));
         }
     }
 }

--- a/src/DynamicData.Tests/List/PageFixture.cs
+++ b/src/DynamicData.Tests/List/PageFixture.cs
@@ -36,7 +36,7 @@ namespace DynamicData.Tests.List
             var people = _generator.Take(100).ToArray();
             _source.AddRange(people);
             var expected = people.Take(25).ToArray();
-            _results.Data.Items.ShouldAllBeEquivalentTo(expected);
+            _results.Data.Items.Should().BeEquivalentTo(expected);
         }
 
         [Fact]
@@ -47,7 +47,7 @@ namespace DynamicData.Tests.List
             _requestSubject.OnNext(new PageRequest(2, 25));
 
             var expected = people.Skip(25).Take(25).ToArray();
-            _results.Data.Items.ShouldAllBeEquivalentTo(expected);
+            _results.Data.Items.Should().BeEquivalentTo(expected);
         }
 
         [Fact]
@@ -58,7 +58,7 @@ namespace DynamicData.Tests.List
             var expected = people.Take(25).ToArray();
 
             _source.InsertRange(_generator.Take(100), 50);
-            _results.Data.Items.ShouldAllBeEquivalentTo(expected);
+            _results.Data.Items.Should().BeEquivalentTo(expected);
         }
 
         [Fact]
@@ -87,7 +87,7 @@ namespace DynamicData.Tests.List
             _source.RemoveAt(0);
             var expected = people.Skip(26).Take(25).ToArray();
 
-            _results.Data.Items.ShouldAllBeEquivalentTo(expected);
+            _results.Data.Items.Should().BeEquivalentTo(expected);
 
             var removedMessage = _results.Messages[2].ElementAt(0);
             var removedPerson = people.ElementAt(25);

--- a/src/DynamicData.Tests/List/RemoveManyFixture.cs
+++ b/src/DynamicData.Tests/List/RemoveManyFixture.cs
@@ -21,7 +21,7 @@ namespace DynamicData.Tests.List
         {
             _list.AddRange(Enumerable.Range(1, 10));
             _list.RemoveMany(Enumerable.Range(2, 8));
-            _list.ShouldAllBeEquivalentTo(new[] {1, 10});
+            _list.Should().BeEquivalentTo(new[] {1, 10});
         }
 
         [Fact]
@@ -29,7 +29,7 @@ namespace DynamicData.Tests.List
         {
             _list.AddRange(new[] {1, 1, 1, 5, 6, 7});
             _list.RemoveMany(new[] {1, 1, 7});
-            _list.ShouldAllBeEquivalentTo(new[] {1, 5, 6});
+            _list.Should().BeEquivalentTo(new[] {1, 5, 6});
         }
 
         [Fact]
@@ -40,7 +40,7 @@ namespace DynamicData.Tests.List
 
             var toRemove = _list.Take(_list.Count / 2).OrderBy(x => Guid.NewGuid()).ToArray();
             _list.RemoveMany(toRemove);
-            _list.ShouldAllBeEquivalentTo(toAdd.Except(toRemove));
+            _list.Should().BeEquivalentTo(toAdd.Except(toRemove));
         }
     }
 }

--- a/src/DynamicData.Tests/List/ReverseFixture.cs
+++ b/src/DynamicData.Tests/List/ReverseFixture.cs
@@ -32,14 +32,14 @@ namespace DynamicData.Tests.List
             _source.Add(4);
             _source.Add(5);
 
-            _results.Data.Items.ShouldAllBeEquivalentTo(new[] {5, 4, 3, 2, 1});
+            _results.Data.Items.Should().BeEquivalentTo(new[] {5, 4, 3, 2, 1});
         }
 
         [Fact]
         public void AddRange()
         {
             _source.AddRange(Enumerable.Range(1, 5));
-            _results.Data.Items.ShouldAllBeEquivalentTo(new[] {5, 4, 3, 2, 1});
+            _results.Data.Items.Should().BeEquivalentTo(new[] {5, 4, 3, 2, 1});
         }
 
         [Fact]
@@ -48,7 +48,7 @@ namespace DynamicData.Tests.List
             _source.AddRange(Enumerable.Range(1, 5));
             _source.Remove(1);
             _source.Remove(4);
-            _results.Data.Items.ShouldAllBeEquivalentTo(new[] {5, 3, 2});
+            _results.Data.Items.Should().BeEquivalentTo(new[] {5, 3, 2});
         }
 
         [Fact]
@@ -56,7 +56,7 @@ namespace DynamicData.Tests.List
         {
             _source.AddRange(Enumerable.Range(1, 5));
             _source.RemoveRange(1, 3);
-            _results.Data.Items.ShouldAllBeEquivalentTo(new[] {5, 1});
+            _results.Data.Items.Should().BeEquivalentTo(new[] {5, 1});
         }
 
         [Fact]
@@ -65,7 +65,7 @@ namespace DynamicData.Tests.List
             _source.AddRange(Enumerable.Range(1, 5));
             _source.RemoveRange(1, 3);
             _source.Insert(1, 3);
-            _results.Data.Items.ShouldAllBeEquivalentTo(new[] {5, 3, 1});
+            _results.Data.Items.Should().BeEquivalentTo(new[] {5, 3, 1});
         }
 
         [Fact]
@@ -73,7 +73,7 @@ namespace DynamicData.Tests.List
         {
             _source.AddRange(Enumerable.Range(1, 5));
             _source.ReplaceAt(2, 100);
-            _results.Data.Items.ShouldAllBeEquivalentTo(new[] {5, 4, 100, 2, 1});
+            _results.Data.Items.Should().BeEquivalentTo(new[] {5, 4, 100, 2, 1});
         }
 
         [Fact]
@@ -89,7 +89,7 @@ namespace DynamicData.Tests.List
         {
             _source.AddRange(Enumerable.Range(1, 5));
             _source.Move(4, 1);
-            _results.Data.Items.ShouldAllBeEquivalentTo(new[] {4, 3, 2, 5, 1});
+            _results.Data.Items.Should().BeEquivalentTo(new[] {4, 3, 2, 5, 1});
         }
 
         [Fact]
@@ -97,7 +97,7 @@ namespace DynamicData.Tests.List
         {
             _source.AddRange(Enumerable.Range(1, 5));
             _source.Move(1, 4);
-            _results.Data.Items.ShouldAllBeEquivalentTo(new[] {2, 5, 4, 3, 1});
+            _results.Data.Items.Should().BeEquivalentTo(new[] {2, 5, 4, 3, 1});
         }
     }
 }

--- a/src/DynamicData.Tests/List/SelectFixture.cs
+++ b/src/DynamicData.Tests/List/SelectFixture.cs
@@ -84,7 +84,7 @@ namespace DynamicData.Tests.List
             _results.Messages[0].Adds.Should().Be(100, "Should return 100 adds");
 
             var transformed = people.Select(_transformFactory).OrderBy(p => p.Age).ToArray();
-            _results.Data.Items.OrderBy(p => p.Age).ShouldAllBeEquivalentTo(transformed, "Incorrect transform result");
+            _results.Data.Items.OrderBy(p => p.Age).Should().BeEquivalentTo(transformed, "Incorrect transform result");
         }
 
         [Fact]

--- a/src/DynamicData.Tests/List/SortFixture.cs
+++ b/src/DynamicData.Tests/List/SortFixture.cs
@@ -42,7 +42,7 @@ namespace DynamicData.Tests.List
             var expectedResult = people.OrderBy(p => p, _comparer);
             var actualResult = _results.Data.Items;
 
-            actualResult.ShouldAllBeEquivalentTo(expectedResult);
+            actualResult.Should().BeEquivalentTo(expectedResult);
         }
 
         [Fact]
@@ -89,7 +89,7 @@ namespace DynamicData.Tests.List
 
             var expectedResult = people.OrderBy(p => p, _comparer);
             var actualResult = _results.Data.Items;
-            actualResult.ShouldAllBeEquivalentTo(expectedResult);
+            actualResult.Should().BeEquivalentTo(expectedResult);
         }
 
         [Fact]
@@ -105,7 +105,7 @@ namespace DynamicData.Tests.List
 
             var expectedResult = people.OrderBy(p => p, _comparer).Take(10);
             var actualResult = _results.Data.Items;
-            actualResult.ShouldAllBeEquivalentTo(expectedResult);
+            actualResult.Should().BeEquivalentTo(expectedResult);
         }
 
         [Fact]
@@ -121,7 +121,7 @@ namespace DynamicData.Tests.List
 
             var expectedResult = people.OrderByDescending(p => p, _comparer).Take(10);
             var actualResult = _results.Data.Items;
-            actualResult.ShouldAllBeEquivalentTo(expectedResult);
+            actualResult.Should().BeEquivalentTo(expectedResult);
         }
 
         [Fact]
@@ -139,7 +139,7 @@ namespace DynamicData.Tests.List
 
             var expectedResult = people.Except(odd).OrderByDescending(p => p, _comparer).ToArray();
             var actualResult = _results.Data.Items;
-            actualResult.ShouldAllBeEquivalentTo(expectedResult);
+            actualResult.Should().BeEquivalentTo(expectedResult);
         }
     }
 }

--- a/src/DynamicData.Tests/List/SortMutableFixture.cs
+++ b/src/DynamicData.Tests/List/SortMutableFixture.cs
@@ -51,7 +51,7 @@ namespace DynamicData.Tests.List
             var expectedResult = people.OrderBy(p => p, _comparer);
             var actualResult = _results.Data.Items;
 
-            actualResult.ShouldAllBeEquivalentTo(expectedResult);
+            actualResult.Should().BeEquivalentTo(expectedResult);
         }
 
         [Fact]
@@ -98,7 +98,7 @@ namespace DynamicData.Tests.List
 
             var expectedResult = people.OrderBy(p => p, _comparer);
             var actualResult = _results.Data.Items;
-            actualResult.ShouldAllBeEquivalentTo(expectedResult);
+            actualResult.Should().BeEquivalentTo(expectedResult);
         }
 
         [Fact]
@@ -114,7 +114,7 @@ namespace DynamicData.Tests.List
 
             var expectedResult = people.OrderBy(p => p, _comparer).Take(10);
             var actualResult = _results.Data.Items;
-            actualResult.ShouldAllBeEquivalentTo(expectedResult);
+            actualResult.Should().BeEquivalentTo(expectedResult);
         }
 
         [Fact]
@@ -130,7 +130,7 @@ namespace DynamicData.Tests.List
 
             var expectedResult = people.OrderByDescending(p => p, _comparer).Take(10);
             var actualResult = _results.Data.Items;
-            actualResult.ShouldAllBeEquivalentTo(expectedResult);
+            actualResult.Should().BeEquivalentTo(expectedResult);
         }
 
         [Fact]
@@ -155,7 +155,7 @@ namespace DynamicData.Tests.List
             var actualResult = _results.Data.Items.ToArray();
 
             //actualResult.(expectedResult);
-            actualResult.ShouldAllBeEquivalentTo(expectedResult);
+            actualResult.Should().BeEquivalentTo(expectedResult);
         }
 
         [Fact]
@@ -173,7 +173,7 @@ namespace DynamicData.Tests.List
 
             var expectedResult = people.Except(odd).OrderByDescending(p => p, _comparer).ToArray();
             var actualResult = _results.Data.Items;
-            actualResult.ShouldAllBeEquivalentTo(expectedResult);
+            actualResult.Should().BeEquivalentTo(expectedResult);
         }
 
         [Fact]
@@ -191,7 +191,7 @@ namespace DynamicData.Tests.List
             var expectedResult = people.OrderBy(p => p, _comparer);
             var actualResult = _results.Data.Items;
 
-            actualResult.ShouldAllBeEquivalentTo(expectedResult);
+            actualResult.Should().BeEquivalentTo(expectedResult);
         }
 
         [Fact]
@@ -210,7 +210,7 @@ namespace DynamicData.Tests.List
             var expectedResult = people.OrderBy(p => p, newComparer);
             var actualResult = _results.Data.Items;
 
-            actualResult.ShouldAllBeEquivalentTo(expectedResult);
+            actualResult.Should().BeEquivalentTo(expectedResult);
         }
 
         [Fact]
@@ -229,7 +229,7 @@ namespace DynamicData.Tests.List
             var expectedResult = people.Union(morePeople).OrderBy(p => p, _comparer).ToArray();
             var actualResult = _results.Data.Items;
 
-            actualResult.ShouldAllBeEquivalentTo(expectedResult);
+            actualResult.Should().BeEquivalentTo(expectedResult);
 
             _results.Messages.Count.Should().Be(2, "Should be 2 messages");
 

--- a/src/DynamicData.Tests/List/SortPrimitiveFixture.cs
+++ b/src/DynamicData.Tests/List/SortPrimitiveFixture.cs
@@ -38,7 +38,7 @@ namespace DynamicData.Tests.List
             var expectedResult = items.OrderBy(p => p, _comparer);
             var actualResult = _results.Data.Items;
 
-            actualResult.ShouldAllBeEquivalentTo(expectedResult);
+            actualResult.Should().BeEquivalentTo(expectedResult);
 
             for (int i = 0; i < 50; i++)
             {

--- a/src/DynamicData.Tests/List/SwitchFixture.cs
+++ b/src/DynamicData.Tests/List/SwitchFixture.cs
@@ -35,7 +35,7 @@ namespace DynamicData.Tests.List
 
             _results.Data.Count.Should().Be(100);
 
-            inital.ShouldAllBeEquivalentTo(_source.Items);
+            inital.Should().BeEquivalentTo(_source.Items);
         }
 
         [Fact]

--- a/src/DynamicData.Tests/List/ToObservableChangeSetFixture.cs
+++ b/src/DynamicData.Tests/List/ToObservableChangeSetFixture.cs
@@ -51,7 +51,7 @@ namespace DynamicData.Tests.List
 
             var expected = new[] {_person2, _person3};
 
-            _target.ShouldAllBeEquivalentTo(expected);
+            _target.Should().BeEquivalentTo(expected);
         }
     }
 }

--- a/src/DynamicData.Tests/List/TransformAsyncFixture.cs
+++ b/src/DynamicData.Tests/List/TransformAsyncFixture.cs
@@ -92,7 +92,7 @@ namespace DynamicData.Tests.List
         //    var result = await Task.WhenAll(tasks);
 
         //    var transformed = result.OrderBy(p => p.Age).ToArray();
-        //    _results.Data.Items.OrderBy(p => p.Age).ShouldAllBeEquivalentTo(_results.Data.Items.OrderBy(p => p.Age), "Incorrect transform result");
+        //    _results.Data.Items.OrderBy(p => p.Age).Should().BeEquivalentTo(_results.Data.Items.OrderBy(p => p.Age), "Incorrect transform result");
         //}
 
         //[Fact]

--- a/src/DynamicData.Tests/List/TransformFixture.cs
+++ b/src/DynamicData.Tests/List/TransformFixture.cs
@@ -100,7 +100,7 @@ namespace DynamicData.Tests.List
             _results.Messages[0].Adds.Should().Be(100, "Should return 100 adds");
 
             var transformed = people.Select(_transformFactory).OrderBy(p => p.Age).ToArray();
-            _results.Data.Items.OrderBy(p => p.Age).ShouldAllBeEquivalentTo(transformed, "Incorrect transform result");
+            _results.Data.Items.OrderBy(p => p.Age).Should().BeEquivalentTo(transformed, "Incorrect transform result");
         }
 
         [Fact]

--- a/src/DynamicData.Tests/List/TransformManyFixture.cs
+++ b/src/DynamicData.Tests/List/TransformManyFixture.cs
@@ -41,7 +41,7 @@ namespace DynamicData.Tests.List
             _source.Add(mother);
 
             _results.Data.Count.Should().Be(4);
-            _results.Data.Items.ShouldAllBeEquivalentTo(new[] { child1, child2, child3, frientofchild1 });
+            _results.Data.Items.Should().BeEquivalentTo(new[] { child1, child2, child3, frientofchild1 });
         }
 
         [Fact]
@@ -76,7 +76,7 @@ namespace DynamicData.Tests.List
             _source.Replace(mother, updatedMother);
 
             _results.Data.Count.Should().Be(4);
-            _results.Data.Items.ShouldAllBeEquivalentTo(new[] { child1, child2, frientofchild1, child4 });
+            _results.Data.Items.Should().BeEquivalentTo(new[] { child1, child2, frientofchild1, child4 });
         }
 
         [Fact]
@@ -100,7 +100,7 @@ namespace DynamicData.Tests.List
 
             _source.AddRange(new[] {anotherRelative1, anotherRelative2});
             _results.Data.Count.Should().Be(8);
-            _results.Data.Items.ShouldAllBeEquivalentTo(new[] { child1, child2, child3, frientofchild1, child4, child5, child6, child7 });
+            _results.Data.Items.Should().BeEquivalentTo(new[] { child1, child2, child3, frientofchild1, child4, child5, child6, child7 });
 
         }
 
@@ -123,7 +123,7 @@ namespace DynamicData.Tests.List
 
             _source.RemoveRange(0,2);
             _results.Data.Count.Should().Be(2);
-            _results.Data.Items.ShouldAllBeEquivalentTo(new[] { child6, child7 });
+            _results.Data.Items.Should().BeEquivalentTo(new[] { child6, child7 });
 
         }
 
@@ -190,16 +190,16 @@ namespace DynamicData.Tests.List
 
             tourProviders.AddRange(new[] { tp1, tp2, tp3 });
 
-            allTours.Items.ShouldAllBeEquivalentTo(new[] { tour1_1, tour2_1, tour2_2 });
+            allTours.Items.Should().BeEquivalentTo(new[] { tour1_1, tour2_1, tour2_2 });
 
             tp3.Tours.Add(tour3_1);
-            allTours.Items.ShouldAllBeEquivalentTo(new[] { tour1_1, tour2_1, tour2_2, tour3_1 });
+            allTours.Items.Should().BeEquivalentTo(new[] { tour1_1, tour2_1, tour2_2, tour3_1 });
 
             tp2.Tours.Remove(tour2_1);
-            allTours.Items.ShouldAllBeEquivalentTo(new[] { tour1_1, tour2_2, tour3_1 });
+            allTours.Items.Should().BeEquivalentTo(new[] { tour1_1, tour2_2, tour3_1 });
 
             tp2.Tours.Add(tour2_1);
-            allTours.Items.ShouldAllBeEquivalentTo(new[] { tour1_1, tour2_1, tour2_2, tour3_1 });
+            allTours.Items.Should().BeEquivalentTo(new[] { tour1_1, tour2_1, tour2_2, tour3_1 });
         }
 
         public class TourProvider

--- a/src/DynamicData.Tests/List/TransformManyProjectionFixture.cs
+++ b/src/DynamicData.Tests/List/TransformManyProjectionFixture.cs
@@ -53,7 +53,7 @@ namespace DynamicData.Tests.List
             _source.AddRange(parents);
 
             _results.Count.Should().Be(5);
-            _results.Items.ShouldBeEquivalentTo(parents.SelectMany(p => p.Children.Take(5).Select(c => new ProjectedNestedChild(p, c))));
+            _results.Items.Should().BeEquivalentTo(parents.SelectMany(p => p.Children.Take(5).Select(c => new ProjectedNestedChild(p, c))));
         }
 
         [Fact]
@@ -81,7 +81,7 @@ namespace DynamicData.Tests.List
             //remove a parent and check children have moved
             _source.Remove(parents[0]);
             _results.Count.Should().Be(3);
-            _results.Items.ShouldBeEquivalentTo(parents.Skip(1).SelectMany(p => p.Children.Select(c => new ProjectedNestedChild(p, c))));
+            _results.Items.Should().BeEquivalentTo(parents.Skip(1).SelectMany(p => p.Children.Select(c => new ProjectedNestedChild(p, c))));
         }
 
         [Fact]
@@ -109,7 +109,7 @@ namespace DynamicData.Tests.List
             //remove a child
             parents[1].Children.Remove(children[3]);
             _results.Count.Should().Be(4);
-            _results.Items.ShouldBeEquivalentTo(parents.SelectMany(p => p.Children.Where(child => child.Name != "D").Select(c => new ProjectedNestedChild(p, c))));
+            _results.Items.Should().BeEquivalentTo(parents.SelectMany(p => p.Children.Where(child => child.Name != "D").Select(c => new ProjectedNestedChild(p, c))));
         }
 
         private class ProjectedNestedChild

--- a/src/DynamicData.Tests/List/TransformManyRefreshFixture.cs
+++ b/src/DynamicData.Tests/List/TransformManyRefreshFixture.cs
@@ -40,7 +40,7 @@ namespace DynamicData.Tests.List
             person.Friends = new[] {friend1, friend2};
 
             _results.Data.Count.Should().Be(2, "Should be 2 in the cache");
-            _results.Data.Items.ShouldAllBeEquivalentTo(new[] {friend1, friend2});
+            _results.Data.Items.Should().BeEquivalentTo(new[] {friend1, friend2});
         }
 
         [Fact]
@@ -56,7 +56,7 @@ namespace DynamicData.Tests.List
             person.Age = 55;
 
             _results.Data.Count.Should().Be(2, "Should be 2 in the cache");
-            _results.Data.Items.ShouldAllBeEquivalentTo(new[] {friend1, friend2});
+            _results.Data.Items.Should().BeEquivalentTo(new[] {friend1, friend2});
         }
 
         [Fact]
@@ -73,7 +73,7 @@ namespace DynamicData.Tests.List
             person.Friends = new[] {friend4};
 
             _results.Data.Count.Should().Be(2, "Should be 2 in the cache");
-            _results.Data.Items.ShouldAllBeEquivalentTo(new[] {friend4, friend2});
+            _results.Data.Items.Should().BeEquivalentTo(new[] {friend4, friend2});
         }
 
     }

--- a/src/DynamicData.Tests/List/VirtualisationFixture.cs
+++ b/src/DynamicData.Tests/List/VirtualisationFixture.cs
@@ -35,7 +35,7 @@ namespace DynamicData.Tests.List
 
             var expected = people.Take(25).ToArray();
 
-            _results.Data.Items.ShouldAllBeEquivalentTo(expected);
+            _results.Data.Items.Should().BeEquivalentTo(expected);
         }
 
         [Fact]
@@ -46,7 +46,7 @@ namespace DynamicData.Tests.List
             _requestSubject.OnNext(new VirtualRequest(25, 25));
 
             var expected = people.Skip(25).Take(25).ToArray();
-            _results.Data.Items.ShouldAllBeEquivalentTo(expected);
+            _results.Data.Items.Should().BeEquivalentTo(expected);
         }
 
         [Fact]
@@ -58,7 +58,7 @@ namespace DynamicData.Tests.List
             var expected = people.Take(25).ToArray();
 
             _source.InsertRange(_generator.Take(100), 50);
-            _results.Data.Items.ShouldAllBeEquivalentTo(expected);
+            _results.Data.Items.Should().BeEquivalentTo(expected);
         }
 
         [Fact]
@@ -87,7 +87,7 @@ namespace DynamicData.Tests.List
             _source.RemoveAt(0);
             var expected = people.Skip(26).Take(25).ToArray();
 
-            _results.Data.Items.ShouldAllBeEquivalentTo(expected);
+            _results.Data.Items.Should().BeEquivalentTo(expected);
 
             var removedMessage = _results.Messages[2].ElementAt(0);
             var removedPerson = people.ElementAt(25);

--- a/src/DynamicData.Tests/List/XOrFixture.cs
+++ b/src/DynamicData.Tests/List/XOrFixture.cs
@@ -86,7 +86,7 @@ namespace DynamicData.Tests.List
             _source1.AddRange(Enumerable.Range(1, 5));
             _source2.AddRange(Enumerable.Range(6, 5));
             _results.Data.Count.Should().Be(10);
-            _results.Data.Items.ShouldAllBeEquivalentTo(Enumerable.Range(1, 10));
+            _results.Data.Items.Should().BeEquivalentTo(Enumerable.Range(1, 10));
         }
 
         [Fact]
@@ -96,7 +96,7 @@ namespace DynamicData.Tests.List
             _source2.AddRange(Enumerable.Range(6, 5));
             _source1.Clear();
             _results.Data.Count.Should().Be(5);
-            _results.Data.Items.ShouldAllBeEquivalentTo(Enumerable.Range(6, 5));
+            _results.Data.Items.Should().BeEquivalentTo(Enumerable.Range(6, 5));
         }
 
         [Fact]
@@ -105,7 +105,7 @@ namespace DynamicData.Tests.List
             _source1.AddRange(Enumerable.Range(1, 10));
             _source2.AddRange(Enumerable.Range(6, 10));
             _results.Data.Count.Should().Be(10);
-            _results.Data.Items.ShouldAllBeEquivalentTo(Enumerable.Range(1, 5).Union(Enumerable.Range(11, 5)));
+            _results.Data.Items.Should().BeEquivalentTo(Enumerable.Range(1, 5).Union(Enumerable.Range(11, 5)));
         }
     }
 }


### PR DESCRIPTION
This is a manual upgrade for fluent assertions.

I have to do a find and replace for collections asserts as the old system of `AllShouldBeEquivalentTo` was removed in v5