### PR TITLE
SourceCache optional key EqualityComparer parameter

### DIFF
--- a/src/DynamicData.Tests/Cache/CustomComparerFixture.cs
+++ b/src/DynamicData.Tests/Cache/CustomComparerFixture.cs
@@ -42,19 +42,23 @@ namespace DynamicData.Tests.Cache
         [Fact]
         public void DefaultComparer()
         {
-            using var people = Construct(keyEqualityComparer: null);
-            Assert.True(people.Lookup(ExistingKey).HasValue);
-            Assert.False(people.Lookup(NonExistentKey).HasValue);
-            Assert.False(people.Lookup(ExistingButMismatchedKey).HasValue);
+            using (var people = Construct(keyEqualityComparer: null))
+            {
+                Assert.True(people.Lookup(ExistingKey).HasValue);
+                Assert.False(people.Lookup(NonExistentKey).HasValue);
+                Assert.False(people.Lookup(ExistingButMismatchedKey).HasValue);
+            }
         }
 
         [Fact]
         public void CustomComparer()
         {
-            using var people = Construct(keyEqualityComparer: StringComparer.OrdinalIgnoreCase);
-            Assert.True(people.Lookup(ExistingKey).HasValue);
-            Assert.False(people.Lookup(NonExistentKey).HasValue);
-            Assert.True(people.Lookup(ExistingButMismatchedKey).HasValue);
+            using (var people = Construct(keyEqualityComparer: StringComparer.OrdinalIgnoreCase))
+            {
+                Assert.True(people.Lookup(ExistingKey).HasValue);
+                Assert.False(people.Lookup(NonExistentKey).HasValue);
+                Assert.True(people.Lookup(ExistingButMismatchedKey).HasValue);
+            }
         }
 
         [Fact]

--- a/src/DynamicData.Tests/Cache/CustomComparerFixture.cs
+++ b/src/DynamicData.Tests/Cache/CustomComparerFixture.cs
@@ -1,0 +1,124 @@
+﻿using DynamicData.Annotations;
+using DynamicData.Cache.Internal;
+using DynamicData.Tests.Domain;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace DynamicData.Tests.Cache
+{
+    public class CustomComparerFixture
+    {
+        public const string ExistingKey = "PersonThatExists";
+        public const string NonExistentKey = "PersonThatDoesNotExist";
+        public const string ExistingButMismatchedKey = "PersonThatEXISTS";
+
+        private SourceCache<Person, string> Construct(IEqualityComparer<string> keyEqualityComparer)
+        {
+            var people = new SourceCache<Person, string>(p => p.Name, keyEqualityComparer: keyEqualityComparer);
+            people.AddOrUpdate(Enumerable.Range(1, 10)
+                .Select(i => new Person("Person" + i, i)));
+            people.AddOrUpdate(new Person(ExistingKey, 15));
+            return people;
+        }
+
+        private ReaderWriter<Person, string> ConstructReaderWriter(IEqualityComparer<string> keyEqualityComparer)
+        {
+            var people = new ReaderWriter<Person, string>(p => p.Name, keyEqualityComparer: keyEqualityComparer);
+            people.Write(
+                updateAction: (updater) =>
+                {
+                    updater.AddOrUpdate(Enumerable.Range(1, 10)
+                        .Select(i => new Person("Person" + i, i)));
+                    updater.AddOrUpdate(new Person(ExistingKey, 15));
+                },
+                previewHandler: null,
+                collectChanges: false);
+            return people;
+        }
+
+        [Fact]
+        public void DefaultComparer()
+        {
+            using var people = Construct(keyEqualityComparer: null);
+            Assert.True(people.Lookup(ExistingKey).HasValue);
+            Assert.False(people.Lookup(NonExistentKey).HasValue);
+            Assert.False(people.Lookup(ExistingButMismatchedKey).HasValue);
+        }
+
+        [Fact]
+        public void CustomComparer()
+        {
+            using var people = Construct(keyEqualityComparer: StringComparer.OrdinalIgnoreCase);
+            Assert.True(people.Lookup(ExistingKey).HasValue);
+            Assert.False(people.Lookup(NonExistentKey).HasValue);
+            Assert.True(people.Lookup(ExistingButMismatchedKey).HasValue);
+        }
+
+        [Fact]
+        public void ReaderWriterDefaultComparer()
+        {
+            var people = ConstructReaderWriter(keyEqualityComparer: null);
+            Assert.True(people.Lookup(ExistingKey).HasValue);
+            Assert.False(people.Lookup(NonExistentKey).HasValue);
+            Assert.False(people.Lookup(ExistingButMismatchedKey).HasValue);
+        }
+
+        [Fact]
+        public void ReaderWriterCustomComparer()
+        {
+            var people = ConstructReaderWriter(keyEqualityComparer: StringComparer.OrdinalIgnoreCase);
+            Assert.True(people.Lookup(ExistingKey).HasValue);
+            Assert.False(people.Lookup(NonExistentKey).HasValue);
+            Assert.True(people.Lookup(ExistingButMismatchedKey).HasValue);
+        }
+
+        [Fact]
+        public void ReaderWriterDuringPreview()
+        {
+            var people = ConstructReaderWriter(keyEqualityComparer: null);
+            people.Write(
+                updateAction: (updater) =>
+                {
+                    Assert.True(updater.Lookup(ExistingKey).HasValue);
+                    Assert.False(updater.Lookup(NonExistentKey).HasValue);
+                    Assert.False(updater.Lookup(ExistingButMismatchedKey).HasValue);
+                    Assert.True(people.Lookup(ExistingKey).HasValue);
+                    Assert.False(people.Lookup(NonExistentKey).HasValue);
+                    Assert.False(people.Lookup(ExistingButMismatchedKey).HasValue);
+                },
+                previewHandler: (preview) =>
+                {
+                    Assert.True(people.Lookup(ExistingKey).HasValue);
+                    Assert.False(people.Lookup(NonExistentKey).HasValue);
+                    Assert.False(people.Lookup(ExistingButMismatchedKey).HasValue);
+                },
+                collectChanges: false);
+        }
+
+        [Fact]
+        public void ReaderWriterCustomComparerDuringPreview()
+        {
+            var people = ConstructReaderWriter(keyEqualityComparer: StringComparer.OrdinalIgnoreCase);
+            people.Write(
+                updateAction: (updater) =>
+                {
+                    Assert.True(updater.Lookup(ExistingKey).HasValue);
+                    Assert.False(updater.Lookup(NonExistentKey).HasValue);
+                    Assert.True(updater.Lookup(ExistingButMismatchedKey).HasValue);
+                    Assert.True(people.Lookup(ExistingKey).HasValue);
+                    Assert.False(people.Lookup(NonExistentKey).HasValue);
+                    Assert.True(people.Lookup(ExistingButMismatchedKey).HasValue);
+                },
+                previewHandler: (preview) =>
+                {
+                    Assert.True(people.Lookup(ExistingKey).HasValue);
+                    Assert.False(people.Lookup(NonExistentKey).HasValue);
+                    Assert.True(people.Lookup(ExistingButMismatchedKey).HasValue);
+                },
+                collectChanges: false);
+        }
+    }
+}

--- a/src/DynamicData/Cache/Internal/ReaderWriter.cs
+++ b/src/DynamicData/Cache/Internal/ReaderWriter.cs
@@ -21,7 +21,7 @@ namespace DynamicData.Cache.Internal
         {
             _keySelector = keySelector;
             _keyEqualityComparer = keyEqualityComparer ?? EqualityComparer<TKey>.Default;
-            //could do with priming this on first time load
+            // could do with priming this on first time load
             _data = new Dictionary<TKey, TObject>(_keyEqualityComparer);
         }
 

--- a/src/DynamicData/Cache/ObservableCache.cs
+++ b/src/DynamicData/Cache/ObservableCache.cs
@@ -58,9 +58,9 @@ namespace DynamicData
             });
         }
 
-        public ObservableCache(Func<TObject, TKey> keySelector = null)
+        public ObservableCache(Func<TObject, TKey> keySelector = null, IEqualityComparer<TKey> keyEqualityComparer = null)
         {
-            _readerWriter = new ReaderWriter<TObject, TKey>(keySelector);
+            _readerWriter = new ReaderWriter<TObject, TKey>(keySelector, keyEqualityComparer);
 
             _cleanUp = Disposable.Create(() =>
             {

--- a/src/DynamicData/Cache/SourceCache.cs
+++ b/src/DynamicData/Cache/SourceCache.cs
@@ -23,7 +23,10 @@ namespace DynamicData
         /// Initializes a new instance of the <see cref="SourceCache{TObject, TKey}"/> class.
         /// </summary>
         /// <param name="keySelector">The key selector.</param>
-        /// <param name="keyEqualityComparer">The comparer to use to determine if two keys are equivalent</param>
+        /// <param name="keyEqualityComparer">
+        /// The comparer to use to determine if two keys are equivalent.
+        /// If null is provided, the default comparer will be used.
+        /// </param>
         /// <exception cref="System.ArgumentNullException">keySelector</exception>
         public SourceCache(Func<TObject, TKey> keySelector, IEqualityComparer<TKey> keyEqualityComparer = null)
         {

--- a/src/DynamicData/Cache/SourceCache.cs
+++ b/src/DynamicData/Cache/SourceCache.cs
@@ -23,15 +23,16 @@ namespace DynamicData
         /// Initializes a new instance of the <see cref="SourceCache{TObject, TKey}"/> class.
         /// </summary>
         /// <param name="keySelector">The key selector.</param>
+        /// <param name="keyEqualityComparer">The comparer to use to determine if two keys are equivalent</param>
         /// <exception cref="System.ArgumentNullException">keySelector</exception>
-        public SourceCache(Func<TObject, TKey> keySelector)
+        public SourceCache(Func<TObject, TKey> keySelector, IEqualityComparer<TKey> keyEqualityComparer = null)
         {
             if (keySelector == null)
             {
                 throw new ArgumentNullException(nameof(keySelector));
             }
 
-            _innerCache = new ObservableCache<TObject, TKey>(keySelector);
+            _innerCache = new ObservableCache<TObject, TKey>(keySelector, keyEqualityComparer);
         }
 
         #region Delegated Members


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Allows the user to specify if they want a SourceCache to utilize a special key comparer internally.  

Example usage:
```
var cache = new SourceCache<MyObject, string>(
    keySelector: o => o.MyString,
    keyEqualityComparer: StringComparer.OrdinalIgnoreCase);
cache.AddOrUpdate(new MyObject()
{
    MyString = "lowercase"
});
Assert.True(cache.Lookup("LOWERCASE").HasValue);
```

**What is the current behavior?**
No way to specify custom comparers in a SourceCache.



**What is the new behavior?**
Optional parameter on SourceCache allows for any comparer to be specified for the keys.



**What might this PR break?**
Internally, within the `ReaderWriter` class that actually uses the comparer, there might be some mismatches in the special logic within the preview functionality.  I added specific tests for this code section to help ensure correctness.

**Other notes**
The custom comparer supplied to a SourceCache in no way trickles down to any .Connect() observable chains.  But it's not certain that would be desirable anyway.