### PR TITLE
ISourceCache.KeySelector

### DIFF
--- a/src/DynamicData/Cache/ISourceCache.cs
+++ b/src/DynamicData/Cache/ISourceCache.cs
@@ -21,5 +21,10 @@ namespace DynamicData
         /// </summary>
         /// <param name="updateAction">The update action.</param>
         void Edit(Action<ISourceUpdater<TObject, TKey>> updateAction);
+
+        /// <summary>
+        /// Key selector used by the cache to retrieve keys from objects
+        /// </summary>
+        Func<TObject, TKey> KeySelector { get; }
     }
 }

--- a/src/DynamicData/Cache/SourceCache.cs
+++ b/src/DynamicData/Cache/SourceCache.cs
@@ -26,13 +26,8 @@ namespace DynamicData
         /// <exception cref="System.ArgumentNullException">keySelector</exception>
         public SourceCache(Func<TObject, TKey> keySelector)
         {
-            if (keySelector == null)
-            {
-                throw new ArgumentNullException(nameof(keySelector));
-            }
-
+            KeySelector = keySelector ?? throw new ArgumentNullException(nameof(keySelector));
             _innerCache = new ObservableCache<TObject, TKey>(keySelector);
-            KeySelector = keySelector;
         }
 
         #region Delegated Members

--- a/src/DynamicData/Cache/SourceCache.cs
+++ b/src/DynamicData/Cache/SourceCache.cs
@@ -32,6 +32,7 @@ namespace DynamicData
             }
 
             _innerCache = new ObservableCache<TObject, TKey>(keySelector);
+            KeySelector = keySelector;
         }
 
         #region Delegated Members
@@ -61,6 +62,8 @@ namespace DynamicData
 
         /// <inheritdoc />
         public IEnumerable<TKey> Keys => _innerCache.Keys;
+
+        public Func<TObject, TKey> KeySelector { get; }
 
         /// <inheritdoc />
         public Optional<TObject> Lookup(TKey key) => _innerCache.Lookup(key);


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Adds a public getter for the KeySelector func that a SourceCache uses for retrieving keys from objects.



**What is the current behavior?**
A user of a cache has no way to determine how a key is retrieved from an object by the cache.  A user must be fed the same func in parallel alongside the cache to do any intelligent logic that needs to align and get the same keys.



**What is the new behavior?**
A getter only property is exposed by ISourceCache to give the user access to the func used internally.



**What might this PR break?**
I don't think it will break any code, but may or may not have undesirable API exposure effects.


**Other information**:
I think the main discussion will probably just be around whether this should be exposed or not.  A user might want to give a cache a key selector "in secret", and/or intend the key selector to only be used by the cache, for some reason.  In these cases, exposing the func to an outside user via the interface will allow outside users to call the func in unexpected ways.

I think the chances of that scenario are pretty low.  So the main issue might just be cluttering the interface.

I do think the change will make some operations/logic much more robust, as the Key Selector doesn't have to be passed around in parallel with a cache in order to be used.  The cache -knows- what selector it's using, it's just currently not telling anybody.

Here's an example snippet.  This whole thing may be obsolete and better handled a different way, but let's use it for example anyway:
```
public static void SetTo<V, K>(
    this ISourceCache<V, K> cache, 
    Func<V, K> keySelector, 
    IEnumerable<V> items, 
    SetToEnum setTo = SetToEnum.Whitewash)
{
    if (setTo == SetToEnum.Whitewash)
    {
        cache.Clear();
        cache.AddOrUpdate(items);
        return;
    }
    var toRemove = new HashSet<K>(cache.Keys);
    var keyPairs = items.Select(i => new KeyValuePair<K, V>(keySelector(i), i)).ToArray();
    toRemove.Remove(keyPairs.Select(kv => kv.Key));
    cache.Remove(toRemove);
    switch (setTo)
    {
        case SetToEnum.SkipExisting:
            foreach (var item in keyPairs)
            {
                var lookup = cache.Lookup(item.Key);
                if (!lookup.HasValue)
                {
                    cache.AddOrUpdate(item.Value);
                }
            }
            break;
        case SetToEnum.SetExisting:
            cache.AddOrUpdate(items);
            break;
        default:
            throw new NotImplementedException();
    }
}
```

I would prefer to be able to remove the need for a keySelector parameter here, as it should be an implicit property of the cache, in my opinion.

Needing to provide a keySelector to this extension function actually increases the potential for mistakes, as a misaligned keySelector (one that the cache isn't actually using) will result in bad results.  The user needs to ensure the keySelectors match, but has no way of confirming this whatsoever.

Being able to just ask the cache what selector it is using, and utilize that for the logic would be much safer and easier to use.
