### PR TITLE
Use replace instead of remove+add on ObservableCollectionAdaptor.DoUpdate

### DIFF
--- a/src/DynamicData.Tests/Binding/ObservableCollectionBindCacheFixture.cs
+++ b/src/DynamicData.Tests/Binding/ObservableCollectionBindCacheFixture.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Specialized;
 using System.Linq;
+using System.Reactive.Linq;
 using DynamicData.Binding;
 using DynamicData.Tests.Domain;
 using FluentAssertions;
@@ -47,6 +49,25 @@ namespace DynamicData.Tests.Binding
 
             _collection.Count.Should().Be(1, "Should be 1 item in the collection");
             _collection.First().Should().Be(personUpdated, "Should be updated person");
+        }
+
+        [Fact]
+        public void UpdateToSourceSendsReplaceOnDestination()
+        {
+            var person = new Person("Adult1", 50);
+            var anotherPerson = new Person("Adult1", 51);
+            NotifyCollectionChangedAction action = default;
+            _source.AddOrUpdate(person);
+
+            using (_collection
+                .ObserveCollectionChanges()
+                .Select(x => x.EventArgs.Action)
+                .Subscribe(updateType => action = updateType))
+            {
+                _source.AddOrUpdate(anotherPerson);
+            }
+
+            action.Should().Be(NotifyCollectionChangedAction.Replace, "The notification type should be Replace");
         }
 
         [Fact]

--- a/src/DynamicData/Binding/ObservableCollectionAdaptor.cs
+++ b/src/DynamicData/Binding/ObservableCollectionAdaptor.cs
@@ -127,8 +127,7 @@ namespace DynamicData.Binding
                         list.Remove(update.Current);
                         break;
                     case ChangeReason.Update:
-                        list.Remove(update.Previous.Value);
-                        list.Add(update.Current);
+                        list.Replace(update.Previous.Value, update.Current);
                         break;
                 }
             }


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bug fix

**What is the current behavior?**
https://github.com/reactiveui/DynamicData/issues/378

**What is the new behavior?**
ObservableCollectionAdaptor will use the Replace ext method in order to trigger a
NotifyCollectionChangedAction.Replace event action type

**What might this PR break?**
Uses that rely on this behavior: https://github.com/reactiveui/DynamicData/issues/378

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [not needed] Docs have been added / updated (for bug fixes / features)

