### PR TITLE
Optimize ListEx.Clone by using the is operator

### DIFF
--- a/src/DynamicData.Tests/List/CloneChangesFixture.cs
+++ b/src/DynamicData.Tests/List/CloneChangesFixture.cs
@@ -186,5 +186,32 @@ namespace DynamicData.Tests.List
 
             itemMoved.Should().BeTrue();
         }
+
+        [Fact]
+        public void MovedItemInListLowerToHigherIsMoved()
+        {
+            _source.AddRange(Enumerable.Range(1, 10));
+            _source.Move(1, 2);
+
+            var changes = _source.CaptureChanges();
+
+            _clone.Clone(changes);
+
+            _clone.Should().BeEquivalentTo(_source);
+        }
+
+        [Fact]
+        public void MovedItemInListHigherToLowerIsMoved()
+        {
+            _source.AddRange(Enumerable.Range(1, 10));
+            _source.Move(2, 1);
+
+            var changes = _source.CaptureChanges();
+
+            _clone.Clone(changes);
+
+            _clone.Should().BeEquivalentTo(_source);
+        }
+
     }
 }

--- a/src/DynamicData/List/ListEx.cs
+++ b/src/DynamicData/List/ListEx.cs
@@ -228,17 +228,15 @@ namespace DynamicData
                     var change = item.Item;
                     bool hasIndex = change.CurrentIndex >= 0;
                     if (!hasIndex)
-                        {
-                            throw new UnspecifiedIndexException("Cannot move as an index was not specified");
-                        }
+                    {
+                        throw new UnspecifiedIndexException("Cannot move as an index was not specified");
+                    }
 
-                        var extendedList = source as IExtendedList<T>;
-                    var observableCollection = source as ObservableCollection<T>;
-                    if (extendedList != null)
+                    if (source is IExtendedList<T> extendedList)
                     {
                         extendedList.Move(change.PreviousIndex, change.CurrentIndex);
                     }
-                    else if (observableCollection != null)
+                    else if (source is ObservableCollection<T> observableCollection)
                     {
                         observableCollection.Move(change.PreviousIndex, change.CurrentIndex);
                     }


### PR DESCRIPTION
Fix inconsistent indentation
Add unit test for ListEx.Clone for Move on a plain List

**What kind of change does this PR introduce?**
Optimization/simplification and code cleanup.

**What is the current behavior?**
As expected

**What is the new behavior?**
Same but with cleaner/optimized code and more unit tests to prove it works.

**What might this PR break?**
Nothing

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

