### PR TITLE
[BUG] SortedObservableCollectionAdaptor does Remove -> Add instead of Replace when index not changed

### DIFF
--- a/src/DynamicData/Binding/SortedObservableCollectionAdaptor.cs
+++ b/src/DynamicData/Binding/SortedObservableCollectionAdaptor.cs
@@ -103,8 +103,16 @@ namespace DynamicData.Binding
                         list.Move(update.PreviousIndex, update.CurrentIndex);
                         break;
                     case ChangeReason.Update:
-                        list.RemoveAt(update.PreviousIndex);
-                        list.Insert(update.CurrentIndex, update.Current);
+                        if (update.PreviousIndex != update.CurrentIndex)
+                        {
+                            list.RemoveAt(update.PreviousIndex);
+                            list.Insert(update.CurrentIndex, update.Current);
+                        }
+                        else
+                        {
+                            list.Replace(update.Previous.Value, update.Current);
+                        }
+
                         break;
                 }
             }


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bug fix



**What is the current behavior?**
#391 



**What is the new behavior?**
<!-- If this is a feature change -->
SortedObservableCollectionAdaptor.DoUpdate uses Replace if the updated item's index does not change from the update.
The behavior stays the same if the index is changed.


**What might this PR break?**
Uses that rely on #391 



**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- `not needed` Docs have been added / updated (for bug fixes / features)
